### PR TITLE
feature/legistar-utils-cleanup-and-scrapers-dict-init

### DIFF
--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -27,3 +27,7 @@ for submodule in iter_modules(__path__):
         ):
             # Attach the class to scrapers with it's municipality name
             SCRAPERS[member_cls.MUNICIPALITY_SLUG] = member_cls
+
+# Not inhereting from the LegistarScraper?
+# Add your scraper class here
+# SCRAPERS[{municipality_slug}] = {class_def}

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -7,14 +7,14 @@ Individual scratchpad and maybe up-to-date CDP instance scrapers.
 from pkgutil import iter_modules
 import importlib
 import inspect
-from typing import Dict
+from typing import Dict, Type
 
 from cdp_scrapers.legistar_utils import LegistarScraper
 
 ###############################################################################
 
 
-SCRAPERS: Dict[str, LegistarScraper] = {}
+SCRAPERS: Dict[str, Type[LegistarScraper]] = {}
 for submodule in iter_modules(__path__):
     # Import the submodule
     mod = importlib.import_module(f"{__name__}.{submodule.name}")

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -48,7 +48,7 @@ for submodule in iter_modules(__path__):
             SCRAPER_FUNCTIONS[member_cls.PYTHON_MUNICIPALITY_SLUG] = scraper_get_events
 
 # Not inhereting from the LegistarScraper?
-# Add your scraper class here
+# Add your scraper function here
 # SCRAPER_FUNCTIONS[{python_municipality_slug}] = {function_callable}
 
 # Set all scraper functions as exports of this module

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -6,6 +6,7 @@ Individual scratchpad and maybe up-to-date CDP instance scrapers.
 
 import importlib
 import inspect
+import sys
 from datetime import datetime
 from functools import partial
 from pkgutil import iter_modules
@@ -19,9 +20,9 @@ from cdp_scrapers.legistar_utils import LegistarScraper
 
 
 def _init_and_run_get_events(
-    legistar_scraper: Type[LegistarScraper],
     from_dt: datetime,
     to_dt: datetime,
+    legistar_scraper: Type[LegistarScraper],
     **kwargs: Any,
 ) -> List[EventIngestionModel]:
     scraper = legistar_scraper()
@@ -44,8 +45,12 @@ for submodule in iter_modules(__path__):
                 legistar_scraper=member_cls,
             )
             # Attach the partial function to the scraper functions dict
-            SCRAPER_FUNCTIONS[member_cls.MUNICIPALITY_SLUG] = scraper_get_events
+            SCRAPER_FUNCTIONS[member_cls.PYTHON_MUNICIPALITY_SLUG] = scraper_get_events
 
 # Not inhereting from the LegistarScraper?
 # Add your scraper class here
-# SCRAPER_FUNCTIONS[{municipality_slug}] = {function_callable}
+# SCRAPER_FUNCTIONS[{python_municipality_slug}] = {function_callable}
+
+# Set all scraper functions as exports of this module
+for python_municipality_slug, func in SCRAPER_FUNCTIONS.items():
+    setattr(sys.modules[__name__], f"get_{python_municipality_slug}_events", func)

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -3,3 +3,27 @@
 """
 Individual scratchpad and maybe up-to-date CDP instance scrapers.
 """
+
+from pkgutil import iter_modules
+import importlib
+import inspect
+from typing import Dict
+
+from cdp_scrapers.legistar_utils import LegistarScraper
+
+###############################################################################
+
+
+SCRAPERS: Dict[str, LegistarScraper] = {}
+for submodule in iter_modules(__path__):
+    # Import the submodule
+    mod = importlib.import_module(f"{__name__}.{submodule.name}")
+
+    # Get the scraper from the module
+    for a, member_cls in inspect.getmembers(mod, inspect.isclass):
+        if (
+            issubclass(member_cls, LegistarScraper)
+            and member_cls is not LegistarScraper
+        ):
+            # Attach the class to scrapers with it's municipality name
+            SCRAPERS[member_cls.MUNICIPALITY_SLUG] = member_cls

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -26,6 +26,8 @@ log = logging.getLogger(__name__)
 
 
 class KingCountyScraper(LegistarScraper):
+    MUNICIPALITY_SLUG: str = "king-county"
+
     def __init__(self):
         """
         King County specific implementation of LegistarScraper.

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -28,9 +28,23 @@ log = logging.getLogger(__name__)
 class KingCountyScraper(LegistarScraper):
     def __init__(self):
         """
-        kingcounty-specific implementation of LegistarScraper
+        King County specific implementation of LegistarScraper.
         """
-        super().__init__("kingcounty")
+        super().__init__(
+            client="kingcounty",
+            timezone="America/Los_Angeles",
+            ignore_minutes_item_patterns=[
+                "This meeting also constitutes a meeting of the City Council",
+                "In-person attendance is currently prohibited",
+                "Times listed are estimated",
+                "has been cancelled",
+                "Deputy City Clerk",
+                "Paste the following link into the address bar of your web browser",
+                "HOW TO WATCH",
+                "page break",
+                "PUBLIC NOTICE",
+            ],
+        )
 
     def get_video_uris(self, legistar_ev: Dict) -> List[Dict]:
         """
@@ -38,15 +52,17 @@ class KingCountyScraper(LegistarScraper):
 
         Parameters
         ----------
-        legistar_ev : Dict
-            Data for one Legistar Event obtained from
-            ..legistar_utils.get_legistar_events_for_timespan()
+        legistar_ev: Dict
+            Data for one Legistar Event.
 
         Returns
         -------
-        List[Dict]
-            List of video and caption URI
-            [{"video_uri": ..., "caption_uri": ...}, ...]
+        video_and_caption_uris: List[Dict]
+            List of Dict containing video and caption URI for each session found.
+
+        See Also
+        --------
+        cdp_scrapers.legistar_utils.get_legistar_events_for_timespan
         """
         try:
             # a td tag with a certain id pattern containing url to video
@@ -120,15 +136,3 @@ class KingCountyScraper(LegistarScraper):
         if len(list_uri) == 0:
             log.debug(f"No video URI found on {video_page_url}")
         return list_uri
-
-    def get_time_zone(self) -> str:
-
-        """
-        Return America Los Angeles (old: US/Pacific) time zone name.
-        Can call find_time_zone() to find dynamically.
-        Returns
-        -------
-        time zone name : str
-            "America/Los_Angeles"
-        """
-        return "America/Los_Angeles"

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 class KingCountyScraper(LegistarScraper):
-    MUNICIPALITY_SLUG: str = "king-county"
+    PYTHON_MUNICIPALITY_SLUG: str = "king_county"
 
     def __init__(self):
         """

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Dict, List
-from bs4 import BeautifulSoup
-import re
 import logging
+import re
+from typing import Dict, List
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
-from urllib.error import (
-    URLError,
-    HTTPError,
-)
+
+from bs4 import BeautifulSoup
 
 from ..legistar_utils import (
-    LegistarScraper,
-    CDP_VIDEO_URI,
     CDP_CAPTION_URI,
+    CDP_VIDEO_URI,
     LEGISTAR_EV_SITE_URL,
+    LegistarScraper,
 )
 
 ###############################################################################

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -1,25 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
+import re
 from datetime import datetime
 from typing import Any, Dict, List
-from bs4 import BeautifulSoup
-import re
-import logging
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
-from urllib.error import (
-    URLError,
-    HTTPError,
-)
+
+from bs4 import BeautifulSoup
+from cdp_backend.pipeline.ingestion_models import EventIngestionModel
 
 from ..legistar_utils import (
-    LegistarScraper,
-    CDP_VIDEO_URI,
     CDP_CAPTION_URI,
+    CDP_VIDEO_URI,
     LEGISTAR_EV_SITE_URL,
+    LegistarScraper,
 )
-
-from cdp_backend.pipeline.ingestion_models import EventIngestionModel
 
 ###############################################################################
 

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -31,9 +31,19 @@ log = logging.getLogger(__name__)
 class SeattleScraper(LegistarScraper):
     def __init__(self):
         """
-        Seattle-specific implementation of LegistarScraper
+        Seattle specific implementation of LegistarScraper.
         """
-        super().__init__("seattle")
+        super().__init__(
+            client="seattle",
+            timezone="America/Los_Angeles",
+            ignore_minutes_item_patterns=[
+                "This meeting also constitutes a meeting of the City Council",
+                "In-person attendance is currently prohibited",
+                "Times listed are estimated",
+                "has been cancelled",
+                "Deputy City Clerk",
+            ],
+        )
 
     def get_video_uris(self, legistar_ev: Dict) -> List[Dict]:
         """
@@ -41,15 +51,17 @@ class SeattleScraper(LegistarScraper):
 
         Parameters
         ----------
-        legistar_ev : Dict
-            Data for one Legistar Event obtained from
-            ..legistar_utils.get_legistar_events_for_timespan()
+        legistar_ev: Dict
+            Data for one Legistar Event.
 
         Returns
         -------
-        List[Dict]
-            List of video and caption URI
-            [{"video_uri": ..., "caption_uri": ...}, ...]
+        video_and_caption_uris: List[Dict]
+            List of Dict containing video and caption URI for each session found.
+
+        See Also
+        --------
+        cdp_scrapers.legistar_utils.get_legistar_events_for_timespan
         """
         try:
             # a td tag with a certain id pattern containing url to video
@@ -166,18 +178,6 @@ class SeattleScraper(LegistarScraper):
         if len(list_uri) == 0:
             log.debug(f"No video URI found on {video_page_url}")
         return list_uri
-
-    def get_time_zone(self) -> str:
-        """
-        Return America Los Angeles (old: US/Pacific) time zone name.
-        Can call find_time_zone() to find dynamically.
-
-        Returns
-        -------
-        time zone name : str
-            "America/Los_Angeles"
-        """
-        return "America/Los_Angeles"
 
 
 def get_events(

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 class SeattleScraper(LegistarScraper):
-    MUNICIPALITY_SLUG: str = "seattle"
+    PYTHON_MUNICIPALITY_SLUG: str = "seattle"
 
     def __init__(self):
         """

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -3,13 +3,11 @@
 
 import logging
 import re
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Dict, List
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 from bs4 import BeautifulSoup
-from cdp_backend.pipeline.ingestion_models import EventIngestionModel
 
 from ..legistar_utils import (
     CDP_CAPTION_URI,

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -177,14 +177,3 @@ class SeattleScraper(LegistarScraper):
         if len(list_uri) == 0:
             log.debug(f"No video URI found on {video_page_url}")
         return list_uri
-
-
-def get_events(
-    from_dt: datetime,
-    to_dt: datetime,
-    **kwargs: Any,
-) -> List[EventIngestionModel]:
-    """
-    Implimentation of the Seattle Scrapper to provide to a cookiecutter or for testing.
-    """
-    return SeattleScraper().get_events(begin=from_dt, end=to_dt)

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -29,6 +29,8 @@ log = logging.getLogger(__name__)
 
 
 class SeattleScraper(LegistarScraper):
+    MUNICIPALITY_SLUG: str = "seattle"
+
     def __init__(self):
         """
         Seattle specific implementation of LegistarScraper.

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -248,7 +248,7 @@ class LegistarScraper:
     Parameters
     ----------
     client: str
-        Legistar client name, e.g. "seattle" for Seattle
+        Legistar client name, e.g. "seattle" for Seattle, "kingcounty" for King County.
     timezone: str
         The timezone for the target client.
         i.e. "America/Los_Angeles" or "America/New_York"

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -132,6 +132,7 @@ def get_legistar_events_for_timespan(
         begin = datetime.utcnow() - timedelta(days=1)
     if end is None:
         end = datetime.utcnow()
+
     # The unformatted request parts
     filter_datetime_format = "EventDate+{op}+datetime%27{dt}%27"
     request_format = LEGISTAR_EVENT_BASE + "?$filter={begin}+and+{end}"
@@ -151,6 +152,7 @@ def get_legistar_events_for_timespan(
             ),
         )
     ).json()
+
     # Get all event items for each event
     item_request_format = (
         LEGISTAR_EVENT_BASE
@@ -171,6 +173,7 @@ def get_legistar_events_for_timespan(
                     event_item_id=event_item["EventItemId"],
                 )
             ).json()
+
             # Get person information
             for vote_info in event_item["EventItemVoteInfo"]:
                 person_request_format = LEGISTAR_PERSON_BASE + "/{person_id}"
@@ -187,17 +190,16 @@ def get_legistar_events_for_timespan(
 
 def str_simplified(input_str: str) -> str:
     """
-    Remove leading/trailing whitespaces,
-    simplify multiple whitespaces,
-    unify newline characters
+    Remove leading and trailing whitespaces, simplify multiple whitespaces, unify
+    newline characters.
 
     Parameters
     ----------
-    input_str : str
+    input_str: str
 
     Returns
     -------
-    str
+    cleaned: str
         input_str stripped if it is a string
     """
     if not isinstance(input_str, str):
@@ -212,20 +214,22 @@ def str_simplified(input_str: str) -> str:
     return input_str
 
 
-def reduced_list(input_list: List[Any], collapse: bool = True) -> List:
+def reduced_list(input_list: List[Any], collapse: bool = True) -> Optional[List]:
     """
     Remove all None items from input_list.
 
     Parameters
     ----------
-    input_list : List[Any]
+    input_list: List[Any]
         Input list from which to filter out items that are None
-    collapse : bool, default = True
+    collapse: bool, default = True
         If True, return None in place of an empty list
 
     Returns
     -------
-    List | None
+    reduced_list: Optional[List]
+        All items in the original list except for None values.
+        None if all items were None and collapse is True.
     """
     filtered = [item for item in input_list if item is not None]
     if collapse and len(filtered) == 0:
@@ -238,308 +242,241 @@ class LegistarScraper:
     """
     Base class for transforming Legistar API data to CDP IngestionModel.
 
-    A given installation must define a derived class and implement get_video_uris()
-    and get_time_zone() functions.
+    If get_events() naively fails and raises an error, a given installation must define
+    a derived class and implement the get_video_uris() function.
 
     Parameters
     ----------
     client: str
         Legistar client name, e.g. "seattle" for Seattle
+    timezone: str
+        The timezone for the target client.
+        i.e. "America/Los_Angeles" or "America/New_York"
+        See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for canonical
+        timezones.
+    ignore_minutes_item_patterns: List[str]
+        A list of string patterns or substrings to act as a minutes item filter.
+        Any item in the provided list will be compiled as a regex string and any
+        minute's item that contains the compiled pattern will be filtered out of the
+        produced CDP minutes item list.
+        Default: [] (do not filter any minutes items)
+    vote_approve_pattern: str
+        Regex pattern used to convert Legistar instance's votes in approval value to CDP
+        constant value.
+        Default: "approve|favor|yes"
+    vote_abstain_pattern: str
+        Regex pattern used to convert Legistar instance's abstension value to CDP
+        constant value. Note, this is a pure abstension, not an "approval by
+        abstention" or "rejection by abstension" value. Those should be places in
+        vote_approve_pattern and vote_reject_pattern respectively.
+        Default: "abstain|refuse|refrain"
+    vote_reject_pattern: str
+        Regex pattern used to convert Legistar instance's votes in rejection value to
+        CDP constant value.
+        Default: "reject|oppose|no"
+    vote_absent_pattern: str
+        Regex pattern used to convert Legistar instance's excused absense value to CDP
+        constant value.
+        Default: "absent"
+    vote_nonvoting_pattern: str
+        Regex pattern used to convert Legistar instance's non-voting value to CDP
+        constant value.
+        Default: "nv|(?:non.*voting)"
+    matter_adopted_pattern: str
+        Regex pattern used to convert Legistar instance's matter was adopted to CDP
+        constant value.
+        Default: "approved|confirmed|passed|adopted"
+    matter_in_progess_pattern: str
+        Regex pattern used to convert Legistar instance's matter is in-progress to
+        CDP constant value.
+        Default: "heard|ready|filed|held|(?:in\s*committee)"
+    matter_rejected_pattern: str
+        Regex pattern used to convert Legistar instance's matter was rejected to CDP
+        constant value.
+        Default: "rejected|dropped"
+    minutes_item_decision_passed_pattern: str
+        Regex pattern used to convert Legistar instance's minutes item passage to CDP
+        constant value.
+        Default: "pass"
+    minutes_item_decision_failed_pattern: str
+        Regex pattern used to convert Legistar instance's minutes item failure to CDP
+        constant value.
+        Default: "not|fail"
 
     See Also
     --------
+    cdp_scrapers.legistar_utils.LegistarScraper.get_video_uris
     cdp_scrapers.instances.seattle.SeattleScraper
-    """
+    """  # noqa: W605
 
-    def __init__(self, client: str):
+    def __init__(
+        self,
+        client: str,
+        timezone: str,
+        ignore_minutes_item_patterns: List[str] = [],
+        vote_approve_pattern: str = r"approve|favor|yes",
+        vote_abstain_pattern: str = r"abstain|refuse|refrain",
+        vote_reject_pattern: str = r"reject|oppose|no",
+        vote_absent_pattern: str = r"absent",
+        vote_nonvoting_pattern: str = r"nv|(?:non.*voting)",
+        matter_adopted_pattern: str = r"approved|confirmed|passed|adopted",
+        matter_in_progress_pattern: str = r"heard|ready|filed|held|(?:in\s*committee)",
+        matter_rejected_pattern: str = r"rejected|dropped",
+        minutes_item_decision_passed_pattern: str = r"pass",
+        minutes_item_decision_failed_pattern: str = r"not|fail",
+    ):
         self.client_name: str = client
-
-        # EventMinutesItem is ignored from ingestion if minutes_item contains this
-        self.IGNORED_MINUTE_ITEMS: List[str] = [
-            "This meeting also constitutes a meeting of the City Council",
-            "In-person attendance is currently prohibited",
-            "Times listed are estimated",
-            "has been cancelled",
-            "Deputy City Clerk",
-            "Paste the following link into the address bar of your web browser",
-            "HOW TO WATCH",
-            "page break",
-            "PUBLIC NOTICE",
-            # "CALL TO ORDER",
-            # "ROLL CALL",
-            # "APPROVAL OF THE JOURNAL",
-            # "REFERRAL CALENDAR",
-            # "APPROVAL OF THE AGENDA",
-            # "Items of Business",
-            # "PUBLIC COMMENT",
-            # "PAYMENT OF BILLS",
-            # "COMMITTEE REPORTS",
-            # "OTHER BUSINESS",
-            # "ADJOURNMENT",
-            # "PRESENTATIONS",
-            # "ADOPTION OF OTHER RESOLUTIONS",
-        ]
+        self.timezone: str = timezone
+        self.ignore_minutes_item_patterns: List[str] = ignore_minutes_item_patterns
 
         # regex patterns used to infer cdp_backend.database.constants
         # from Legistar string fields
-        self.vote_approve_pattern: str = "approve|favor|yes"
-        self.vote_abstain_pattern: str = "abstain|refuse|refrain"
-        self.vote_reject_pattern: str = "reject|oppose|no"
+        self.vote_approve_pattern: str = vote_approve_pattern
+        self.vote_abstain_pattern: str = vote_abstain_pattern
+        self.vote_reject_pattern: str = vote_reject_pattern
         # TODO: need to debug these using real examples
-        self.vote_absent_pattern: str = "absent"
-        self.vote_nonvoting_pattern: str = "nv|(?:non.*voting)"
+        self.vote_absent_pattern: str = vote_absent_pattern
+        self.vote_nonvoting_pattern: str = vote_nonvoting_pattern
 
-        self.matter_adopted_pattern: str = "approved|confirmed|passed|adopted"
-        self.matter_in_progress_pattern: str = (
-            r"heard|ready|filed|held|(?:in\s*committee)"
+        self.matter_adopted_pattern: str = matter_adopted_pattern
+        self.matter_in_progress_pattern: str = matter_in_progress_pattern
+        self.matter_rejected_patten: str = matter_rejected_pattern
+
+        self.minutes_item_decision_passed_pattern: str = (
+            minutes_item_decision_passed_pattern
         )
-        self.matter_rejected_patten: str = "rejected|dropped"
+        self.minutes_item_decision_failed_pattern: str = (
+            minutes_item_decision_failed_pattern
+        )
 
-        self.decision_passed_pattern: str = "pass"
-        self.decision_failed_pattern: str = "not|fail"
-
-        # e.g. pytz.timezone("US/Pacific")
-        self.time_zone: timezone = timezone(self.get_time_zone())
-
-    @property
-    def is_legistar_compatible(self) -> bool:
+    @staticmethod
+    def get_required_attrs(model: IngestionModel) -> List[str]:
         """
-        Check that Legistar API recognizes client name
+        Return list of keys required in model as specified in IngestionModel class
+        definition.
+
+        Parameters
+        ----------
+        model: IngestionModel
+            Person, MinutesItem, etc.
 
         Returns
         -------
-        bool
-            True if client_name is a valid Legistar client name
+        attr_keys: List[str]
+            List of keys (attributes) in model without default value in class
+            definition.
         """
-        # simplest check, if the GET request works, it is a legistar municipality
         try:
-            resp = urlopen(f"http://webapi.legistar.com/v1/{self.client_name}/bodies")
-            return resp.status == 200
-        except URLError or HTTPError:
-            return False
-
-    def check_for_cdp_min_ingestion(self, check_days: int = 7) -> bool:
-        """
-        Test if can obtain at least one minimally defined EventIngestionModel
-
-        Parameters
-        ----------
-        check_days : int, default=7
-            Test duration is the past check_days days from now
-
-        Returns
-        -------
-        bool
-            True if got at least one minimally defined EventIngestionModel
-        """
-        # no point wasting time if the client isn't on legistar at all
-        if not self.is_legistar_compatible:
-            return False
-
-        now = datetime.utcnow()
-        days = range(check_days)
-
-        for d in days:
-            begin = now - timedelta(days=d + 1)
-            end = now - timedelta(days=d)
-            log.debug(
-                "Testing for minimal information "
-                f"from {begin.isoformat()} to {end.isoformat()}"
+            # create an empty one to have python tell us what keys are required
+            model.__class__()
+            # all attrs in model have default values
+            return []
+        except TypeError as e:
+            # e.g. __init__() missing 3 required positional arguments:
+            # 'session_datetime', 'video_uri', and 'session_index'
+            match = re.search(
+                r"missing (?P<num_keys>\d+) required.+argument(?:s)?\:\s*(?P<keys>.+)",
+                str(e),
             )
 
-            # ev: EventIngestionModel
-            for cdp_ev in self.get_events(begin=begin, end=end):
-                try:
-                    if (
-                        len(cdp_ev.body.name) > 0
-                        and cdp_ev.sessions[0].session_datetime is not None
-                        and len(cdp_ev.sessions[0].video_uri) > 0
-                    ):
-                        session_time = cdp_ev.sessions[0].session_datetime
-                        log.debug(
-                            f"Got minimal EventIngestionModel for {self.client_name}: "
-                            f"body={cdp_ev.body.name}, "
-                            f"session={session_time.isoformat()}, "
-                            f"video={cdp_ev.sessions[0].video_uri}"
-                        )
-                        return True
+        if not match:
+            log.debug(f"not able to get required attributes for {model.__class__}")
+            return []
 
-                # catch None or empty list
-                except TypeError or IndexError:
-                    pass
+        num_keys = int(match.group("num_keys"))
 
-        log.debug(
-            f"Failed to get minimal EventIngestionModel for {self.client_name} "
-            f"in the past {check_days} days from {now.isoformat()}"
-        )
-        # no event in check_days had enough for minimal ingestion model item
-        return False
+        # 'session_datetime', 'video_uri', and 'session_index'
+        # -> ["session_datetime", "video_uri", "session_index"]
 
-    def get_events(
-        self,
-        begin: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-    ) -> List[EventIngestionModel]:
+        # SHOULD be able to do this more elegantly using re.split()
+        # but couldn't quite get the pattern right
+        keys = re.sub(
+            # TypeError uses
+            # , and
+            # and
+            # ,
+            # as delimiters for attribute names
+            r"(\s*,\s*and\s*)|(\s*and\s*)|(\s*,\s*)",
+            ",",
+            match.group("keys").strip().replace("'", ""),
+        ).split(",")
+
+        if num_keys != len(keys):
+            log.debug(f"{model.__class__} has {num_keys} required keys but got {keys}")
+
+        return keys
+
+    def get_none_if_empty(self, model: IngestionModel) -> Optional[IngestionModel]:
         """
-        Calls get_legistar_events_for_timespan to retrieve Legistar API data
-        and return as List[EventIngestionModel]
+        Check required keys in model, return None if any such key has no value.
+        i.e. If all required keys have valid value, return as-is.
 
         Parameters
         ----------
-        begin : datetime, optional
-            The timespan beginning datetime to query for events after.
-            Default is 2 days from UTC now
-        end : datetime, optional
-            The timespan end datetime to query for events before.
-            Default is UTC now
+        model: IngestionModel
+            Person, MinutesItem, etc.
 
         Returns
         -------
-        List[EventIngestionModel]
-            One instance of EventIngestionModel per Legistar Event
+        model: Optional[IngestionModel]
+            None or model as-is
+        """
+        try:
+            min_keys = self.min_ingestion_keys[model.__class__]
+        except AttributeError:
+            # first time using min_ingestion_keys
+            self.min_ingestion_keys = {}
+            min_keys = None
+        except KeyError:
+            # first time checking model.__class__
+            min_keys = None
+
+        if min_keys is None:
+            min_keys = LegistarScraper.get_required_attrs(model)
+            # cache so we don't do expensive dynamic checking
+            # again for this IngestionModel
+            self.min_ingestion_keys[model.__class__] = min_keys
+
+        if not min_keys:
+            # no required keys for this model
+            # this probably never happens
+            return model
+
+        for key in min_keys:
+            try:
+                val = getattr(model, key)
+
+                # "if not" test to catch all None and None-like values
+                # e.g. empty string, empty list, ...
+                # but int(0) is not "empty"
+                if not val and not isinstance(val, int):
+                    # empty value for this key in model
+                    return None
+            except AttributeError:
+                return None
+
+        # nonempty value for all required keys in model
+        return model
+
+    def get_matter_status(self, legistar_matter_status: str) -> Optional[str]:
+        """
+        Return appropriate MatterStatusDecision constant from EventItemMatterStatus.
+
+        Parameters
+        ----------
+        legistar_matter_status: str
+            Legistar API EventItemMatterStatus.
+
+        Returns
+        -------
+        matter_status: Optional[str]
+            A constant from CDP allowed matter status decisions.
+            None if missing information or if matter status decision parameter patterns
+            are not inclusive to the Legistar matter status value.
 
         See Also
         --------
-        get_legistar_events_for_timespan
-        """
-        if begin is None:
-            begin = datetime.utcnow() - timedelta(days=2)
-        if end is None:
-            end = datetime.utcnow()
-
-        ingestion_models = []
-
-        for legistar_ev in get_legistar_events_for_timespan(
-            self.client_name,
-            begin=begin,
-            end=end,
-        ):
-            # better to return time as local time with time zone info,
-            # rather than as utc time.
-            # this way the calling pipeline can find out what is the local zone.
-            session_time = self.as_local_time(
-                self.date_time_to_datetime(
-                    legistar_ev[LEGISTAR_SESSION_DATE],
-                    legistar_ev[LEGISTAR_SESSION_TIME],
-                )
-            )
-            # prefer video file path in legistar Event.EventVideoPath
-            if legistar_ev[LEGISTAR_SESSION_VIDEO_URI]:
-                list_uri = [
-                    {
-                        CDP_VIDEO_URI: str_simplified(
-                            legistar_ev[LEGISTAR_SESSION_VIDEO_URI]
-                        ),
-                        CDP_CAPTION_URI: None,
-                    }
-                ]
-            else:
-                list_uri = self.get_video_uris(legistar_ev) or [
-                    {CDP_VIDEO_URI: None, CDP_CAPTION_URI: None}
-                ]
-
-            sessions = []
-            sessions = reduced_list(
-                [
-                    self.get_none_if_empty(
-                        Session(
-                            session_datetime=session_time,
-                            session_index=len(sessions),
-                            video_uri=uri[CDP_VIDEO_URI],
-                            caption_uri=uri[CDP_CAPTION_URI],
-                        )
-                    )
-                    # Session per video
-                    for uri in list_uri
-                ]
-            )
-            ingestion_models.append(
-                self.get_none_if_empty(
-                    EventIngestionModel(
-                        agenda_uri=str_simplified(legistar_ev[LEGISTAR_AGENDA_URI]),
-                        minutes_uri=str_simplified(legistar_ev[LEGISTAR_MINUTES_URI]),
-                        body=Body(name=str_simplified(legistar_ev[LEGISTAR_BODY_NAME])),
-                        sessions=sessions,
-                        event_minutes_items=self.get_event_minutes(
-                            legistar_ev[LEGISTAR_EV_ITEMS]
-                        ),
-                    )
-                )
-            )
-
-        # easier for calling pipeline to handle an empty list rather than None
-        # so request reduced_list() to give me [], not None
-        return reduced_list(ingestion_models, collapse=False)
-
-    def get_video_uris(self, legistar_ev: Dict) -> List[Dict]:
-        """
-        Must implement in class derived from LegistarScraper.
-        If Legistar Event.EventVideoPath is used, return an empty list in the override.
-
-        Parameters
-        ----------
-        legstar_ev : Dict
-            Legistar API Event
-
-        Returns
-        -------
-        List[Dict]
-            List of video and caption URI
-            [{"video_uri": ..., "caption_uri": ...}, ...]
-
-        Raises
-        ------
-        NotImplementedError
-            This base implementation does nothing
-        """
-        log.critical(
-            "get_video_uris() is required because "
-            f"Legistar Event.EventVideoPath is not used by {self.client_name}"
-        )
-        raise NotImplementedError
-
-    def get_time_zone(self) -> str:
-        """
-        Return time zone name for CDP instance.
-        To use dynamically determined time zone,
-        use find_time_zone().
-        Returns
-        -------
-        time zone name : str
-            i.e. "America/Los_Angeles" | "America/New_York" ...
-
-        See Also
-        --------
-        SeattleScraper.get_time_zone()
-
-        Notes
-        -----
-        List of Timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-        Please only use "Canonical" timezones.
-        """
-        log.error(
-            "Time zone name required for proper event timestamping. "
-            "e.g. America/Los_Angeles"
-        )
-        raise NotImplementedError
-
-    def get_matter_status(self, legistar_matter_status: str) -> MatterStatusDecision:
-        """
-        Return appropriate MatterStatusDecision constant from EventItemMatterStatus
-
-        Parameters
-        ----------
-        legistar_matter_status : str
-            Legistar API EventItemMatterStatus
-
-        Returns
-        -------
-        MatterStatusDecision
-            ADOPTED | IN_PROGRESS | REJECTED | None
-
-        See Also
-        --------
-        matter_*_pattern
+        cdp_backend.database.constants.MatterStatusDecision
         """
         if not legistar_matter_status:
             return None
@@ -580,31 +517,35 @@ class LegistarScraper:
     def get_minutes_item_decision(
         self,
         legistar_item_passed_name: str,
-    ) -> EventMinutesItemDecision:
+    ) -> Optional[str]:
         """
-        Return appropriate EventMinutesItemDecision constant
-            from EventItemPassedFlagName
+        Return appropriate EventMinutesItemDecision constant from
+        EventItemPassedFlagName.
 
         Parameters
         ----------
-        legistar_item_passed_name : str
+        legistar_item_passed_name: str
             Legistar API EventItemPassedFlagName
 
         Returns
         -------
-        MatterStatusDecision
-            PASSED | FAILED | None
+        emi_decision: Optional[str]
+            A constant from CDP allowed minutes item decisions.
+            None if missing information or if minutes item decision parameter
+            patterns are no inclusive of the Legistar minutes item decision value.
 
         See Also
         --------
-        decision_*_pattern
+        cdp_backend.database.constants.EventMinutesItemDecision
         """
         if not legistar_item_passed_name:
             return None
 
         if (
             re.search(
-                self.decision_passed_pattern, legistar_item_passed_name, re.IGNORECASE
+                self.minutes_item_decision_passed_pattern,
+                legistar_item_passed_name,
+                re.IGNORECASE,
             )
             is not None
         ):
@@ -612,7 +553,9 @@ class LegistarScraper:
 
         if (
             re.search(
-                self.decision_failed_pattern, legistar_item_passed_name, re.IGNORECASE
+                self.minutes_item_decision_failed_pattern,
+                legistar_item_passed_name,
+                re.IGNORECASE,
             )
             is not None
         ):
@@ -620,22 +563,25 @@ class LegistarScraper:
 
         return None
 
-    def get_vote_decision(self, legistar_vote: Dict) -> VoteDecision:
+    def get_vote_decision(self, legistar_vote: Dict) -> Optional[str]:
         """
-        Return appropriate VoteDecision constant based on Legistar Vote
+        Return appropriate VoteDecision constant based on Legistar Vote.
 
         Parameters
         ----------
-        legistar_vote : Dict
+        legistar_vote: Dict
             Legistar API Vote
 
         Returns
         -------
-        VoteDecision | None
+        vote_decision: Optional[str]
+            A constant from CDP allowed vote decisions.
+            None if missing vote information or if vote decision parameter patterns are
+            not inclusive of the Legistar vote value.
 
         See Also
         --------
-        vote_*_pattern
+        cdp_backend.database.constants.VoteDecision
         """
         if (
             not legistar_vote[LEGISTAR_VOTE_VAL_NAME]
@@ -711,18 +657,20 @@ class LegistarScraper:
 
         return decision
 
-    def get_person(self, legistar_person: Dict) -> Person:
+    def get_person(self, legistar_person: Dict) -> Optional[Person]:
         """
-        Return CDP Person for Legistar Person
+        Return CDP Person for Legistar Person.
 
         Parameters
         ----------
-        legistar_person : Dict
+        legistar_person: Dict
             Legistar API Person
 
         Returns
         -------
-        Person | None
+        person: Optional[Person]
+            The Legistar Person converted to a CDP person ingestion model.
+            None if missing information.
         """
         return self.get_none_if_empty(
             Person(
@@ -735,18 +683,20 @@ class LegistarScraper:
             )
         )
 
-    def get_votes(self, legistar_votes: List[Dict]) -> List[Vote]:
+    def get_votes(self, legistar_votes: List[Dict]) -> Optional[List[Vote]]:
         """
-        Return List[Vote] for Legistar API Votes
+        Return List[Vote] for Legistar API Votes.
 
         Parameters
         ----------
-        legistar_votes : List[Dict]
-            Legistar API Votes
+        legistar_votes: List[Dict]
+            Legistar votes as CDP Vote ingestion models.
 
         Returns
         -------
-        List[Vote] | None
+        votes: Optional[List[Vote]]
+            List of votes if any were provided.
+            None if empty list or missing information.
         """
         return reduced_list(
             [
@@ -761,21 +711,23 @@ class LegistarScraper:
             ]
         )
 
-    def get_event_support_files(
+    def get_event_supporting_files(
         self,
         legistar_ev_attachments: List[Dict],
-    ) -> List[SupportingFile]:
+    ) -> Optional[List[SupportingFile]]:
         """
-        Return List[SupportingFile] for Legistar API MatterAttachments
+        Return List[SupportingFile] for Legistar API MatterAttachments.
 
         Parameters
         ----------
-        legistar_ev_attachments : List[Dict]
+        legistar_ev_attachments: List[Dict]
             Legistar API MatterAttachments
 
         Returns
         -------
-        List[SupportingFile] | None
+        files: Optional[List[SupportingFile]]
+            List of supporting files if provided.
+            None if empty list or missing information.
         """
         return reduced_list(
             [
@@ -790,18 +742,20 @@ class LegistarScraper:
             ]
         )
 
-    def get_matter(self, legistar_ev: Dict) -> Matter:
+    def get_matter(self, legistar_ev: Dict) -> Optional[Matter]:
         """
-        Return Matter from Legistar API EventItem
+        Return Matter from Legistar API EventItem.
 
         Parameters
         ----------
-        legistar_ev : Dict
+        legistar_ev: Dict
             Legistar API EventItem
 
         Returns
         -------
-        Matter | None
+        matter: Optional[Matter]
+            List of converted Legistar matter details to CDP matter objects.
+            None if missing information.
         """
         try:
             sponsors = reduced_list(
@@ -831,19 +785,19 @@ class LegistarScraper:
             )
         )
 
-    def get_minutes_item(self, legistar_ev_item: Dict) -> MinutesItem:
+    def get_minutes_item(self, legistar_ev_item: Dict) -> Optional[MinutesItem]:
         """
-        Return MinutesItem from parts of Legistar API EventItem
+        Return MinutesItem from parts of Legistar API EventItem.
 
         Parameters
         ----------
-        legistar_ev_item : Dict
+        legistar_ev_item: Dict
             Legistar API EventItem
 
         Returns
         -------
-        MinutesItem | None
-            None if could not get nonempty MinutesItem.name from EventItem
+        minutes_item: Optional[MinutesItem]
+            None if could not get nonempty MinutesItem.name from EventItem.
         """
 
         return self.get_none_if_empty(
@@ -853,52 +807,9 @@ class LegistarScraper:
             )
         )
 
-    def get_event_minutes(
-        self, legistar_ev_items: List[Dict]
-    ) -> List[EventMinutesItem]:
-        """
-        Return List[EventMinutesItem] for Legistar API EventItems
-
-        Parameters
-        ----------
-        legistar_ev_items : List[Dict]
-            Legistar API EventItems
-
-        Returns
-        -------
-        List[EventMinutesItem] | None
-        """
-        return reduced_list(
-            [
-                self.get_none_if_empty(
-                    self.fix_event_minutes(
-                        # if minutes_item contains unimportant data,
-                        # just make the entire EventMinutesItem = None
-                        self.filter_event_minutes(
-                            EventMinutesItem(
-                                index=item[LEGISTAR_EV_INDEX],
-                                minutes_item=self.get_minutes_item(item),
-                                votes=self.get_votes(item[LEGISTAR_EV_VOTES]),
-                                matter=self.get_matter(item),
-                                decision=self.get_minutes_item_decision(
-                                    item[LEGISTAR_EV_MINUTE_DECISION]
-                                ),
-                                supporting_files=self.get_event_support_files(
-                                    item[LEGISTAR_EV_ATTACHMENTS]
-                                ),
-                            )
-                        ),
-                        item,
-                    )
-                )
-                # EventMinutesItem object per member in EventItems
-                for item in legistar_ev_items
-            ]
-        )
-
     def fix_event_minutes(
-        self, ev_minutes_item: EventMinutesItem, legistar_ev_item: Dict
-    ) -> EventMinutesItem:
+        self, ev_minutes_item: Optional[EventMinutesItem], legistar_ev_item: Dict
+    ) -> Optional[EventMinutesItem]:
         """
         Inspect the MinutesItem and Matter in ev_minutes_item.
         - Move some fields between them to make the information more meaningful.
@@ -906,14 +817,18 @@ class LegistarScraper:
 
         Parameters
         ----------
-        ev_minutes_item : EventMinutesItem
-        legistar_ev_item : Dict
-            Legistar EventItem
+        ev_minutes_item: Optional[EventMinutesItem]
+            The specific event minutes item to clean.
+            Or None if running this function in a loop with multiple event minutes
+            items and you don't want to clean / the emi was filtered out.
+        legistar_ev_item: Dict
+            The original Legistar EventItem.
 
         Returns
         -------
-        EventMinutesItem
-            parts of minutes_item and matter could be modified
+        cleaned_emi: Optional[EventMinutesItem]
+            The cleaned event minutes item. This can clean both the event minutes item
+            and the attached matter information.
         """
         if not ev_minutes_item:
             return ev_minutes_item
@@ -941,143 +856,75 @@ class LegistarScraper:
 
     def filter_event_minutes(
         self, ev_minutes_item: EventMinutesItem
-    ) -> EventMinutesItem:
+    ) -> Optional[EventMinutesItem]:
         """
         Return None if minutes_item.name contains unimportant text
         that we want to ignore
 
         Parameters
         ----------
-        ev_minutes_item : EventMinutesItem
+        ev_minutes_item: EventMinutesItem
 
         Returns
         -------
-        EventMinutesItem | None
-
-        See Also
-        --------
-        IGNORED_MINUTE_ITEMS
+        filtered_event_minutes_items: Optional[EventMinutesItem]
+            The allowed minutes item or None is filtered out.
         """
         if not ev_minutes_item.minutes_item or not ev_minutes_item.minutes_item.name:
             return ev_minutes_item
-        for filter in self.IGNORED_MINUTE_ITEMS:
+        for filter in self.ignore_minutes_item_patterns:
             if re.search(filter, ev_minutes_item.minutes_item.name, re.IGNORECASE):
                 return None
         return ev_minutes_item
 
-    def get_none_if_empty(self, model: IngestionModel) -> IngestionModel:
+    def get_event_minutes(
+        self, legistar_ev_items: List[Dict]
+    ) -> Optional[List[EventMinutesItem]]:
         """
-        Check required keys in model, return None if any such key has no value.
-        i.e. If all required keys have valid value, return as-is
+        Return List[EventMinutesItem] for Legistar API EventItems.
 
         Parameters
         ----------
-        model :
-            Person, MinutesItem, etc.
+        legistar_ev_items: List[Dict]
+            Legistar API EventItems
 
         Returns
         -------
-        IngestionModel | None
-            None or model as-is
+        event_minutes_items: Optional[List[EventMinutesItem]]
+            Filtered set of event minutes items.
         """
-        try:
-            min_keys = self.min_ingestion_keys[model.__class__]
-        except AttributeError:
-            # first time using min_ingestion_keys
-            self.min_ingestion_keys = {}
-            min_keys = None
-        except KeyError:
-            # first time checking model.__class__
-            min_keys = None
+        return reduced_list(
+            [
+                self.get_none_if_empty(
+                    self.fix_event_minutes(
+                        # if minutes_item contains unimportant data,
+                        # just make the entire EventMinutesItem = None
+                        self.filter_event_minutes(
+                            EventMinutesItem(
+                                index=item[LEGISTAR_EV_INDEX],
+                                minutes_item=self.get_minutes_item(item),
+                                votes=self.get_votes(item[LEGISTAR_EV_VOTES]),
+                                matter=self.get_matter(item),
+                                decision=self.get_minutes_item_decision(
+                                    item[LEGISTAR_EV_MINUTE_DECISION]
+                                ),
+                                supporting_files=self.get_event_supporting_files(
+                                    item[LEGISTAR_EV_ATTACHMENTS]
+                                ),
+                            )
+                        ),
+                        item,
+                    )
+                )
+                # EventMinutesItem object per member in EventItems
+                for item in legistar_ev_items
+            ]
+        )
 
-        if min_keys is None:
-            min_keys = self.get_required_attrs(model)
-            # cache so we don't do expensive dynamic checking
-            # again for this IngestionModel
-            self.min_ingestion_keys[model.__class__] = min_keys
-
-        if not min_keys:
-            # no required keys for this model
-            # this probably never happens
-            return model
-
-        for key in min_keys:
-            try:
-                val = getattr(model, key)
-
-                # "if not" test to catch all None and None-like values
-                # e.g. empty string, empty list, ...
-                # but int(0) is not "empty"
-                if not val and not isinstance(val, int):
-                    # empty value for this key in model
-                    return None
-            except AttributeError:
-                return None
-
-        # nonempty value for all required keys in model
-        return model
-
-    def get_required_attrs(self, model: IngestionModel) -> List[str]:
+    @staticmethod
+    def find_time_zone() -> str:
         """
-        Return list of keys required in model as specified
-        in IngestionModel class definition
-
-        Parameters
-        ----------
-        model : IngestionModel
-            Person, MinutesItem, etc.
-
-        Returns
-        -------
-        List[str]
-            List of keys (attributes) in model without default value in class definition
-        """
-        try:
-            # create an empty one to have python tell us what keys are required
-            model.__class__()
-            # all attrs in model have default values
-            return []
-        except TypeError as e:
-            # e.g. __init__() missing 3 required positional arguments:
-            # 'session_datetime', 'video_uri', and 'session_index'
-            match = re.search(
-                r"missing (?P<num_keys>\d+) required.+argument(?:s)?\:\s*(?P<keys>.+)",
-                str(e),
-            )
-
-        if not match:
-            log.debug(f"not able to get required attributes for {model.__class__}")
-            return []
-
-        num_keys = int(match.group("num_keys"))
-
-        # 'session_datetime', 'video_uri', and 'session_index'
-        # -> ["session_datetime", "video_uri", "session_index"]
-
-        # SHOULD be able to do this more elegantly using re.split()
-        # but couldn't quite get the pattern right
-        keys = re.sub(
-            # TypeError uses
-            # , and
-            # and
-            # ,
-            # as delimiters for attribute names
-            r"(\s*,\s*and\s*)|(\s*and\s*)|(\s*,\s*)",
-            ",",
-            match.group("keys").strip().replace("'", ""),
-        ).split(",")
-
-        if num_keys != len(keys):
-            log.debug(f"{model.__class__} has {num_keys} required keys but got {keys}")
-
-        return keys
-
-    def find_time_zone(self) -> str:
-        """
-        Return name for a US time zone matching UTC offset calculated from OS clock
-        Returns
-        -------
-        time zone name : str
+        Return name for a US time zone matching UTC offset calculated from OS clock.
         """
         utc_now = utc.localize(datetime.utcnow())
         local_now = datetime.now()
@@ -1098,37 +945,41 @@ class LegistarScraper:
 
         return None
 
-    def as_local_time(self, local_time: datetime) -> datetime:
+    def localize_datetime(self, local_time: datetime) -> datetime:
         """
         Return input datetime with time zone information.
         This allows for nonambiguous conversions to other zones including UTC.
+
         Parameters
         ----------
-        local_time : datetime
+        local_time: datetime
+            The datetime to attached timezone information to.
+
         Returns
         -------
-        local_time : datetime
+        local_time: datetime
             The date and time attributes (year, month, day, hour, ...) remain unchanged.
             tzinfo is now provided.
         """
         try:
-            return self.time_zone.localize(local_time)
+            return self.timezone.localize(local_time)
         except (AttributeError, ValueError):
             # AttributeError: time_zone or local_time is None
             # ValueError: local_time is not navie (has time zone info)
             return local_time
 
     @staticmethod
-    def date_time_to_datetime(ev_date: str, ev_time: str) -> datetime:
+    def date_and_time_to_datetime(ev_date: str, ev_time: Optional[str]) -> datetime:
         """
         Return datetime from ev_date and ev_time
 
         Parameters
         ----------
-        ev_date : str
+        ev_date: str
             Formatted as "%Y-%m-%dT%H:%M:%S"
-        ev_time : str
+        ev_time: Optional[str]
             Formatted as "%I:%M %p"
+            Or None and do not attach time to date.
 
         Returns
         -------
@@ -1158,3 +1009,203 @@ class LegistarScraper:
                 minute=0,
                 second=0,
             )
+
+    def get_video_uris(self, legistar_ev: Dict) -> List[Dict]:
+        """
+        Must implement in class derived from LegistarScraper.
+        If Legistar Event.EventVideoPath is used, return an empty list in the override.
+
+        Parameters
+        ----------
+        legistar_ev: Dict
+            Data for one Legistar Event.
+
+        Returns
+        -------
+        video_and_caption_uris: List[Dict]
+            List of Dict containing video and caption URI for each session found.
+
+        Raises
+        ------
+        NotImplementedError
+            This base implementation does nothing
+
+        See Also
+        --------
+        cdp_scrapers.legistar_utils.get_legistar_events_for_timespan
+        """
+        log.critical(
+            "get_video_uris() is required because "
+            f"Legistar Event.EventVideoPath is not used by {self.client_name}"
+        )
+        raise NotImplementedError
+
+    def get_events(
+        self,
+        begin: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ) -> List[EventIngestionModel]:
+        """
+        Calls get_legistar_events_for_timespan to retrieve Legistar API data
+        and return as List[EventIngestionModel]
+
+        Parameters
+        ----------
+        begin: datetime, optional
+            The timespan beginning datetime to query for events after.
+            Default is 2 days from UTC now
+        end: datetime, optional
+            The timespan end datetime to query for events before.
+            Default is UTC now
+
+        Returns
+        -------
+        events: List[EventIngestionModel]
+            One instance of EventIngestionModel per Legistar Event
+
+        See Also
+        --------
+        get_legistar_events_for_timespan
+        """
+        if begin is None:
+            begin = datetime.utcnow() - timedelta(days=2)
+        if end is None:
+            end = datetime.utcnow()
+
+        ingestion_models = []
+
+        for legistar_ev in get_legistar_events_for_timespan(
+            self.client_name,
+            begin=begin,
+            end=end,
+        ):
+            # better to return time as local time with time zone info,
+            # rather than as utc time.
+            # this way the calling pipeline can find out what is the local zone.
+            session_time = self.localize_datetime(
+                self.date_and_time_to_datetime(
+                    legistar_ev[LEGISTAR_SESSION_DATE],
+                    legistar_ev[LEGISTAR_SESSION_TIME],
+                )
+            )
+            # prefer video file path in legistar Event.EventVideoPath
+            if legistar_ev[LEGISTAR_SESSION_VIDEO_URI]:
+                list_uri = [
+                    {
+                        CDP_VIDEO_URI: str_simplified(
+                            legistar_ev[LEGISTAR_SESSION_VIDEO_URI]
+                        ),
+                        CDP_CAPTION_URI: None,
+                    }
+                ]
+            else:
+                list_uri = self.get_video_uris(legistar_ev) or [
+                    {CDP_VIDEO_URI: None, CDP_CAPTION_URI: None}
+                ]
+
+            sessions = []
+            sessions = reduced_list(
+                [
+                    self.get_none_if_empty(
+                        Session(
+                            session_datetime=session_time,
+                            session_index=len(sessions),
+                            video_uri=uri[CDP_VIDEO_URI],
+                            caption_uri=uri[CDP_CAPTION_URI],
+                        )
+                    )
+                    # Session per video
+                    for uri in list_uri
+                ]
+            )
+            ingestion_models.append(
+                self.get_none_if_empty(
+                    EventIngestionModel(
+                        agenda_uri=str_simplified(legistar_ev[LEGISTAR_AGENDA_URI]),
+                        minutes_uri=str_simplified(legistar_ev[LEGISTAR_MINUTES_URI]),
+                        body=Body(name=str_simplified(legistar_ev[LEGISTAR_BODY_NAME])),
+                        sessions=sessions,
+                        event_minutes_items=self.get_event_minutes(
+                            legistar_ev[LEGISTAR_EV_ITEMS]
+                        ),
+                    )
+                )
+            )
+
+        # easier for calling pipeline to handle an empty list rather than None
+        # so request reduced_list() to give me [], not None
+        return reduced_list(ingestion_models, collapse=False)
+
+    @property
+    def is_legistar_compatible(self) -> bool:
+        """
+        Check that Legistar API recognizes client name.
+
+        Returns
+        -------
+        compatible: bool
+            True if client_name is a valid Legistar client name
+        """
+        # simplest check, if the GET request works, it is a legistar municipality
+        try:
+            resp = urlopen(f"http://webapi.legistar.com/v1/{self.client_name}/bodies")
+            return resp.status == 200
+        except URLError or HTTPError:
+            return False
+
+    def check_for_cdp_min_ingestion(self, check_days: int = 7) -> bool:
+        """
+        Test if can obtain at least one minimally defined EventIngestionModel
+
+        Parameters
+        ----------
+        check_days: int, default=7
+            Test duration is the past check_days days from now
+
+        Returns
+        -------
+        minimum_ingestion_data_available: bool
+            True if got at least one minimally defined EventIngestionModel
+        """
+        # no point wasting time if the client isn't on legistar at all
+        if not self.is_legistar_compatible:
+            return False
+
+        now = datetime.utcnow()
+        days = range(check_days)
+
+        for d in days:
+            begin = now - timedelta(days=d + 1)
+            end = now - timedelta(days=d)
+            log.debug(
+                "Testing for minimal information "
+                f"from {begin.isoformat()} to {end.isoformat()}"
+            )
+
+            # ev: EventIngestionModel
+            for cdp_ev in self.get_events(begin=begin, end=end):
+                try:
+                    if (
+                        len(cdp_ev.body.name) > 0
+                        and cdp_ev.sessions[0].session_datetime is not None
+                        and len(cdp_ev.sessions[0].video_uri) > 0
+                    ):
+                        session_time = cdp_ev.sessions[0].session_datetime
+                        log.debug(
+                            f"Got minimal EventIngestionModel for {self.client_name}: "
+                            f"body={cdp_ev.body.name}, "
+                            f"session={session_time.isoformat()}, "
+                            f"video={cdp_ev.sessions[0].video_uri}"
+                        )
+                        return True
+
+                # catch None or empty list
+                except TypeError or IndexError:
+                    pass
+
+        log.debug(
+            f"Failed to get minimal EventIngestionModel for {self.client_name} "
+            f"in the past {check_days} days from {now.isoformat()}"
+        )
+        # no event in check_days had enough for minimal ingestion model item
+        return False

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -4,36 +4,29 @@
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
-from urllib.error import URLError, HTTPError
 
 import requests
-
-from cdp_backend.pipeline.ingestion_models import (
-    EventIngestionModel,
-    Body,
-    IngestionModel,
-    Session,
-    EventMinutesItem,
-    MinutesItem,
-    Matter,
-    SupportingFile,
-    Person,
-    Vote,
-)
-
 from cdp_backend.database.constants import (
     EventMinutesItemDecision,
     MatterStatusDecision,
     VoteDecision,
 )
-
-from pytz import (
-    utc,
-    timezone,
-    country_timezones,
+from cdp_backend.pipeline.ingestion_models import (
+    Body,
+    EventIngestionModel,
+    EventMinutesItem,
+    IngestionModel,
+    Matter,
+    MinutesItem,
+    Person,
+    Session,
+    SupportingFile,
+    Vote,
 )
+from pytz import country_timezones, timezone, utc
 
 ###############################################################################
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

W.I.P. for https://github.com/CouncilDataProject/cookiecutter-cdp-deployment/pull/43

### Description of Changes

_Include a description of the proposed changes._

The bulk of this PR is actually cleaning up documentation strings and such. I was working on the simple additions I need for the cookiecutter PR but went through and was my nitpicky self about docstrings.

Core additions:
* All base `LegistarScraper` state is parameterized now. This allows for docstrings for everything and easier understanding of inheriting scrapers to know what they can easily change or not.
* Removal of `get_time_zone` function, is now a `timezone` parameter.
* You can now `from cdp_scrapers.instances import SCRAPER_FUNCTIONS` and receive a `Dict[str, Callable]`.
* Shuffled around the order of the functions on the `LegistarScraper` class itself. The standard that I was taught was to have functions that use other functions last. I.e. function b calls function a, function a should be placed above b in the code.
* SCRAPER_FUNCTIONS are attached to the `instances` module so you can simply import them.

Also note that there is currently no need for special dep handling because both Seattle Scraper and King County Scraper use some pretty basic deps. Once a contributor needs special deps, they will can simply add to the `setup.py`. For scrapers that don't have extra deps, it doesn't matter as python gracefully handles non-existent install mappings. i.e. `pip install cdp_scrapers[seattle]` just warns of missing dep mapping but doesn't fail.

Disregarding the massive docstring changes this PR results in the following as possible:
```python
from datetime import datetime

from cdp_scrapers.instances import get_seattle_events
from cdp_scrapers.instances import get_king_county_events

seattle_events = get_seattle_events(from_dt=datetime(2021, 8, 15), to_dt=datetime(2021, 8, 17))
king_county_events = get_seattle_events(from_dt=datetime(2021, 7, 26), to_dt=datetime(2021, 7, 28))
```

without any import handling from the contributor.