### PR TITLE
adding a method for obtaining the agenda uri

### DIFF
--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -232,7 +232,7 @@ class PortlandScraper(IngestionModelScraper):
 
         return self.get_none_if_empty(
             EventIngestionModel(
-                agenda_uri=None,
+                agenda_uri=self.get_agenda_uri(event_page.soup),
                 # NOTE: have not seen any specific body/bureau named on any agenda page
                 body=Body(name="City Council"),
                 event_minutes_items=self.get_event_minutes(event_page.soup),
@@ -281,3 +281,21 @@ class PortlandScraper(IngestionModelScraper):
             # for easier iterate there
             collapse=False,
         )
+
+    def get_agenda_uri(self, event_page: BeautifulSoup) -> str:
+        """
+        Find the uri for the file containing the agenda at each Portland, OR city
+        council meeting
+
+        Parameters
+        ----------
+        event_page: The page for the meeting
+
+        Returns
+        -------
+        agenda_uri: The uri for the file containing the meeting's agenda
+        """
+        agenda_uri_element = event_page.find("a", {"class": "btn-cta"})
+        if agenda_uri_element is None:
+            return None
+        return agenda_uri_element["href"] + "/File/Document"

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -212,6 +212,30 @@ class PortlandScraper(IngestionModelScraper):
 
         return reduced_list(sessions)
 
+    def get_agenda_uri(self, event_page: BeautifulSoup) -> str:
+        """
+        Find the uri for the file containing the agenda at each Portland, OR city
+        council meeting
+
+        Parameters
+        ----------
+        event_page: The page for the meeting
+
+        Returns
+        -------
+        agenda_uri: The uri for the file containing the meeting's agenda
+        """
+        agenda_uri_element = event_page.find(
+            "a", text=re.compile("Disposition Agenda"), attrs={"class": "btn-cta"}
+        )
+        if agenda_uri_element is not None:
+            return agenda_uri_element["href"] + "/File/Document"
+        parent_agenda_uri_element = event_page.find("div", {"class": "inline-flex"})
+        agenda_uri_element = parent_agenda_uri_element.find("a")
+        if agenda_uri_element is not None:
+            return "https://www.portland.gov" + agenda_uri_element["href"]
+        return None
+
     def get_event(self, event_time: datetime) -> Optional[EventIngestionModel]:
         """
         Information for council meeting on given date if available
@@ -244,30 +268,6 @@ class PortlandScraper(IngestionModelScraper):
                 sessions=self.get_sessions(event_page.soup),
             ),
         )
-
-    def get_agenda_uri(self, event_page: BeautifulSoup) -> str:
-        """
-        Find the uri for the file containing the agenda at each Portland, OR city
-        council meeting
-
-        Parameters
-        ----------
-        event_page: The page for the meeting
-
-        Returns
-        -------
-        agenda_uri: The uri for the file containing the meeting's agenda
-        """
-        agenda_uri_element = event_page.find(
-            "a", text=re.compile("Disposition Agenda"), attrs={"class": "btn-cta"}
-        )
-        if agenda_uri_element is not None:
-            return agenda_uri_element["href"] + "/File/Document"
-        parent_agenda_uri_element = event_page.find("div", {"class": "inline-flex"})
-        agenda_uri_element = parent_agenda_uri_element.find("a")
-        if agenda_uri_element is not None:
-            return "https://www.portland.gov" + agenda_uri_element["href"]
-        return None
 
     def get_events(
         self,

--- a/cdp_scrapers/tests/scraper_tests.py
+++ b/cdp_scrapers/tests/scraper_tests.py
@@ -155,7 +155,16 @@ def test_king_county_scraper(
             1,
             "https://www.youtube.com/embed/aXKE2u24WKg?autoplay=0&start=0&rel=0",
             "https://efiles.portlandoregon.gov/record/14778119/File/Document",
-        )
+        ),
+        (
+            datetime(2022, 1, 12),
+            datetime(2022, 1, 13),
+            1,
+            1,
+            "https://www.youtube.com/embed/TBrJbm08i0g?autoplay=0&start=0&rel=0",
+            "https://www.portland.gov/sites/default/files/2022/"
+            "january-12-2022-agenda-print-version.pdf",
+        ),
     ],
 )
 def test_portland_scraper(

--- a/cdp_scrapers/tests/scraper_tests.py
+++ b/cdp_scrapers/tests/scraper_tests.py
@@ -146,7 +146,7 @@ def test_king_county_scraper(
 
 @pytest.mark.parametrize(
     "start_date_time, end_date_time, number_of_events, number_of_event_minute_items,"
-    "expected_video_uri_in_first_session",
+    "expected_video_uri_in_first_session, expected_agenda_uri",
     [
         (
             datetime(2021, 12, 22),
@@ -154,6 +154,7 @@ def test_king_county_scraper(
             1,
             1,
             "https://www.youtube.com/embed/aXKE2u24WKg?autoplay=0&start=0&rel=0",
+            "https://efiles.portlandoregon.gov/record/14778119/File/Document",
         )
     ],
 )
@@ -163,6 +164,7 @@ def test_portland_scraper(
     number_of_events: int,
     number_of_event_minute_items: int,
     expected_video_uri_in_first_session: str,
+    expected_agenda_uri: str,
 ) -> None:
     portland = PortlandScraper()
     portland_events = portland.get_events(start_date_time, end_date_time)
@@ -171,3 +173,4 @@ def test_portland_scraper(
     assert (
         portland_events[0].sessions[0].video_uri == expected_video_uri_in_first_session
     )
+    assert portland_events[0].agenda_uri == expected_agenda_uri


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request is part of issue #43 

### Description of Changes

This pull request adds a method for obtaining the `agenda_uri` to the Portland scraper as well as a unit test for that.
