### PR TITLE
bugfix/seattle-nelson-picture-uri

### DIFF
--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -133,7 +133,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/images/Council/Members/Nelson/Councilmember-Sara-Nelson_homepage-banner.jpg",
+            "picture_uri": "http://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
             "seat": {
                 "name": "Position 9",
                 "electoral_area": "Citywide",

--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -7,7 +7,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Pedersen/Councilmember-Alex-Pedersen_square-headshot.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Pedersen/Councilmember-Alex-Pedersen_square-headshot.jpg",
             "seat": {
                 "name": "Position 4",
                 "electoral_area": "Northeast Seattle",
@@ -25,7 +25,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Lewis/Andrew-Lewis-Campaign-Headshot_300x300.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Lewis/Andrew-Lewis-Campaign-Headshot_300x300.jpg",
             "seat": {
                 "name": "Position 7",
                 "electoral_area": "Pioneer Square to Magnolia",
@@ -43,7 +43,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Strauss/strauss_headshot_300x300.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Strauss/strauss_headshot_300x300.jpg",
             "seat": {
                 "name": "Position 6",
                 "electoral_area": "Northwest Seattle",
@@ -61,12 +61,12 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Juarez/Debora-Juarez-2018_225x225.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Juarez/Debora-Juarez-2018_225x225.jpg",
             "seat": {
                 "name": "Position 5",
                 "electoral_area": "North Seattle",
                 "electoral_type": null,
-                "image_uri": "http://www.seattle.gov/images/Departments/SDOT/BridgeStairsProgram/AerialRendering_2020.jpg",
+                "image_uri": "https://www.seattle.gov/images/Departments/SDOT/BridgeStairsProgram/AerialRendering_2020.jpg",
                 "external_source_id": null,
                 "roles": null
             },
@@ -79,7 +79,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Sawant/Sawant_225x225.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Sawant/Sawant_225x225.jpg",
             "seat": {
                 "name": "Position 3",
                 "electoral_area": "Central Seattle",
@@ -97,7 +97,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Herbold/Herbold_225x225.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Herbold/Herbold_225x225.jpg",
             "seat": {
                 "name": "Position 1",
                 "electoral_area": "West Seattle",
@@ -115,7 +115,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Gonzalez/Lorena-González_2020-headshot_225x225.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Gonzalez/Lorena-González_2020-headshot_225x225.jpg",
             "seat": {
                 "name": "Position 9",
                 "electoral_area": "Citywide",
@@ -133,7 +133,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
+            "picture_uri": "https://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
             "seat": {
                 "name": "Position 9",
                 "electoral_area": "Citywide",
@@ -151,7 +151,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Morales/Tammy-Morales_headshot_final_300x300.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Morales/Tammy-Morales_headshot_final_300x300.jpg",
             "seat": {
                 "name": "Position 2",
                 "electoral_area": "Southeast Seattle",
@@ -169,7 +169,7 @@
             "email": null,
             "phone": null,
             "website": null,
-            "picture_uri": "http://www.seattle.gov//assets/Images/Council/Members/Mosqueda/Mosqueda_225x225.jpg",
+            "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Mosqueda/Mosqueda_225x225.jpg",
             "seat": {
                 "name": "Position 8",
                 "electoral_area": "Citywide",


### PR DESCRIPTION
### Link to Relevant Issue

Previous picture for Sara Nelson does not work in thumbnail form on the people page in our frontend web site. We want pictures that have the person in the center of the image.

### Description of Changes

_Include a description of the proposed changes._

Changed `picture_uri` for Sara Nelson to http://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg
