### PR TITLE
feature/portland-supporting-files

### DIFF
--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -153,21 +153,21 @@ class PortlandScraper(IngestionModelScraper):
                 "((documents-and-exhibits)|(file-impact-statement)) field--type-file"
             ),
         ):
-            # <a href="/sites/...pdf"><span>Download file</span>
-            # <i class="fas fa-file-alt"></i>Exhibit A</a>
-            link = div.find("a")
-            if link is not None:
-                supporting_files.append(
-                    SupportingFile(
-                        name=str_simplified(
-                            re.sub(r"download\s+file", "", link.text, flags=re.I)
-                        ),
-                        uri=f'https://www.portland.gov{link["href"]}',
+            supporting_files.extend(
+                [
+                    self.get_none_if_empty(
+                        SupportingFile(
+                            name=str_simplified(
+                                re.sub(r"download\s+file", "", link.text, flags=re.I)
+                            ),
+                            uri=f'https://www.portland.gov{link["href"]}',
+                        )
                     )
-                )
-
-        # TODO: now get supporting files that are linked as efiles.
-        #       these links to yet another web page with file download link.
+                    # <a href="/sites/...pdf"><span>Download file</span>
+                    # <i class="fas fa-file-alt"></i>Exhibit A</a>
+                    for link in div.find_all("a")
+                ]
+            )
 
         return reduced_list(
             [self.get_none_if_empty(i) for i in supporting_files],


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is part of #43 

### Description of Changes

_Include a description of the proposed changes._

`PortlandScraper.get_supporting_files(event_page_soup: BeautifulSoup, minutes_item_index: int) -> Optional[List[SupportingFile]]`

Returns list of supporting files for the `minutes_item_index`-th event minutes item on the event web page. `event_page_soup` is a `bs4`-fied object of Portland council event page in the form https://www.portland.gov/council/agenda/yyyy/m/d.

```Python
from cdp_scrapers.instances.portland import load_web_page, PortlandScraper
p = PortlandScraper()

# example with multiple efiles
# https://www.portland.gov/council/documents/report/placed-file/316-2021
p.get_supporting_files(load_web_page("https://www.portland.gov/council/agenda/2021/5/5").soup, 21)
[
    SupportingFile(name='Report', uri='https://efiles.portlandoregon.gov/Record/14463345/File/Document', external_source_id=None),
    SupportingFile(name='Exhibit', uri='https://efiles.portlandoregon.gov/Record/14463346/File/Document', external_source_id=None),
    SupportingFile(name='Additional documents', uri='https://efiles.portlandoregon.gov/Record/14463347/File/Document', external_source_id=None),
    SupportingFile(name='Presentation (PDF)', uri='https://efiles.portlandoregon.gov/Record/14463348/File/Document', external_source_id=None),
    SupportingFile(name='Testimony', uri='https://efiles.portlandoregon.gov/Record/14463349/File/Document', external_source_id=None),
]

# example with multiple non-efiles
# https://www.portland.gov/council/documents/report/findings-adopted/18-2022
p.get_supporting_files(load_web_page("https://www.portland.gov/council/agenda/2022/1/12").soup, 7)
[
    SupportingFile(name='Memo to Council', uri='https://www.portland.gov/sites/default/files/council-documents/2021/lu-21-038539-dz-memo-to-council-120121.doc', external_source_id=None),
    SupportingFile(name='Design Commission Final Findings and Decision', uri='https://www.portland.gov/sites/default/files/council-documents/2021/lu-21-038539-dz-ffdecoct08-120121.pdf', external_source_id=None),
    SupportingFile(name='Appeal', uri='https://www.portland.gov/sites/default/files/council-documents/2021/lu-21-038539-dz-submitted-appeal-120121.pdf', external_source_id=None),
    SupportingFile(name='Hearing Notice', uri='https://www.portland.gov/sites/default/files/council-documents/2021/lu_21_038539_dz_ccnoaoct28-hearing-notice-reduced-file-size.pdf', external_source_id=None),
    SupportingFile(name='Council Findings and Conclusions', uri='https://www.portland.gov/sites/default/files/council-documents/2022/lu-21-038539-dz-council-findings-and-conclusions.pdf', external_source_id=None),
    SupportingFile(name='Impact Statement', uri='https://www.portland.gov/sites/default/files/council-documents/2021/lu-21-038539-dz-impact-statement-120121.docx', external_source_id=None),
]
```

Here efiles refer to files hosted on https://efiles.portlandoregon.gov. Supporting files are linked either as efiles, or as direct links e.g. https://...pdf. I have yet to discover a event minutes item with a mixture of both types of file links.

Not yet using `get_events()` as test because we need to iron out how `get_event()` and maybe downstream methods will specify a particular event minutes item in methods that deal with specific ones, such as `get_supporting_files()`. For example, will we pass the event minutes item index, or some other identifying information. We will decide on that as we fill out `PortlandScraper`.
