### PR TITLE
bugfix/resolve-person-alias

### DIFF
--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -77,6 +77,7 @@ class SeattleScraper(LegistarScraper):
                 "Pursuant to Washington State",
             ],
             known_persons=known_persons,
+            person_aliases={"Dan Strauss": set(["Daniel Strauss"])},
         )
 
     def parse_content_uris(

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -47,6 +47,10 @@ if Path(STATIC_FILE_DEFAULT_PATH).exists():
 if known_persons:
     log.debug(f"loaded static data for {', '.join(known_persons.keys())}")
 
+# we have discovered the city clerk accidentally entered Daniel Strauss
+# instead of the correct Dan Strauss for a few events
+person_aliases = {"Dan Strauss": set(["Daniel Strauss"])}
+
 ###############################################################################
 
 
@@ -77,7 +81,7 @@ class SeattleScraper(LegistarScraper):
                 "Pursuant to Washington State",
             ],
             known_persons=known_persons,
-            person_aliases={"Dan Strauss": set(["Daniel Strauss"])},
+            person_aliases=person_aliases,
         )
 
     def parse_content_uris(

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -49,7 +49,7 @@ if known_persons:
 
 # we have discovered the city clerk accidentally entered Daniel Strauss
 # instead of the correct Dan Strauss for a few events
-person_aliases = {"Dan Strauss": set(["Daniel Strauss"])}
+PERSON_ALIASES = {"Dan Strauss": set(["Daniel Strauss"])}
 
 ###############################################################################
 
@@ -81,7 +81,7 @@ class SeattleScraper(LegistarScraper):
                 "Pursuant to Washington State",
             ],
             known_persons=known_persons,
-            person_aliases=person_aliases,
+            person_aliases=PERSON_ALIASES,
         )
 
     def parse_content_uris(

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -807,20 +807,23 @@ class LegistarScraper(IngestionModelScraper):
                         ),
                     ).json()
                 except JSONDecodeError:
-                    log.error(
-                        f"Found {person.name}, an alias of {name} "
-                        f"but failed get valid JSON for {name} from Legistar API."
-                    )
                     response: List[Dict[str, Any]] = []
 
-                if len(response) > 0 and LEGISTAR_PERSON_EXT_ID in response[0]:
-                    return self.get_person(
-                        get_legistar_person(
-                            self.client_name,
-                            response[0][LEGISTAR_PERSON_EXT_ID],
-                            use_cache=True,
-                        )
+                if len(response) == 0 or LEGISTAR_PERSON_EXT_ID not in response[0]:
+                    log.error(
+                        f"Found {person.name}, an alias of {name} "
+                        f"but failed get valid JSON for {name} from Legistar API. "
+                        f"Keeping this alias {person.name} without resolving."
                     )
+                    return person
+
+                return self.get_person(
+                    get_legistar_person(
+                        self.client_name,
+                        response[0][LEGISTAR_PERSON_EXT_ID],
+                        use_cache=True,
+                    )
+                )
 
         # input person is not an alias of a reference Person
         return person

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -854,7 +854,7 @@ class LegistarScraper(IngestionModelScraper):
             phone = phone.replace("(", "").replace(")", "-")
 
         return self.get_none_if_empty(
-            # If applicable, catch mistakenly entered duplicate persons in the Legistar DB.
+            # If applicable, catch [mistakenly] entered duplicate persons.
             # i.e. Don't create unique Person objects for the same real person.
             self.resolve_person_alias(
                 Person(

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -807,6 +807,10 @@ class LegistarScraper(IngestionModelScraper):
                         ),
                     ).json()
                 except JSONDecodeError:
+                    log.error(
+                        f"Found {person.name}, an alias of {name} "
+                        f"but failed get valid JSON for {name} from Legistar API."
+                    )
                     response: List[Dict[str, Any]] = []
 
                 if len(response) > 0 and LEGISTAR_PERSON_EXT_ID in response[0]:

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -786,9 +786,10 @@ class LegistarScraper(IngestionModelScraper):
 
         See Also
         --------
-        person_aliases in __init__()
+        instances.seattle.person_aliases
         """
-        if not self.person_aliases:
+        # nothing to do if the input person is a reference person itself
+        if not self.person_aliases or person.name in self.person_aliases:
             return person
 
         request_format = (

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -248,4 +248,24 @@ class IngestionModelScraper:
         return model
 
     def resolve_person_alias(self, person: Person) -> Person:
+        """
+        If input person is in fact an alias of a reference known person,
+        return the reference person instead.
+        Else return person as-is.
+
+        Parameters
+        ----------
+        person: Person
+            Person to check whether is an alias or a real unique Person
+
+        Returns
+        -------
+        Person
+            input person, or the correct reference Person if input person is an alias.
+            This base implementation always returns person as-is.
+
+        See Also
+        --------
+        person_aliases in __init__()
+        """
         return person

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -2,9 +2,9 @@ from datetime import datetime
 import logging
 import pytz
 import re
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
-from cdp_backend.pipeline.ingestion_models import IngestionModel
+from cdp_backend.pipeline.ingestion_models import IngestionModel, Person
 
 ###############################################################################
 
@@ -77,13 +77,19 @@ class IngestionModelScraper:
         i.e. "America/Los_Angeles" or "America/New_York"
         See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for canonical
         timezones.
+    person_aliases: Optional[Dict[str, Set[str]]]
+        Dictionary used to catch name aliases
+        and resolve improperly different Persons to the one correct Person.
+        Default: None
     """
 
     def __init__(
         self,
         timezone: str,
+        person_aliases: Optional[Dict[str, Set[str]]] = None,
     ):
         self.timezone: pytz.timezone = pytz.timezone(timezone)
+        self.person_aliases = person_aliases
 
     @staticmethod
     def find_time_zone() -> str:
@@ -240,3 +246,6 @@ class IngestionModelScraper:
 
         # nonempty value for all required keys in model
         return model
+
+    def resolve_person_alias(self, person: Person) -> Person:
+        return person

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -266,6 +266,6 @@ class IngestionModelScraper:
 
         See Also
         --------
-        person_aliases in __init__()
+        instances.seattle.person_aliases
         """
         return person


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #65 

### Description of Changes

_Include a description of the proposed changes._

`resolve_person_alias()` uses `person_alises: Dict[str, Set[str]]` to catch name aliases use the correct reference `Person` in place of the alias `Person`. The base `IngestionModelScraper.resolve_person_alias()` simply returns the input `Person` object as-is.

```Python
class SeattleScraper(LegistarScraper):
    ...
    def __init__(self):
        super().__init__(
            ...
            person_aliases={"Dan Strauss": set(["Daniel Strauss"])},
        )
```

In test,

```Python
from cdp_scrapers.instances.seattle import SeattleScraper
from datetime import datetime
begin = datetime(2021, 9, 14)
end = datetime(2021, 9, 15)
s = SeattleScraper()

# using upstream/main
events = s.get_events(begin=begin, end=end)
print(events[1].event_minutes_items[4].votes[4].person)
# Person(
#     name='Daniel Strauss',
#     email='',
#     ...
# )

# using pr
events = s.get_events(begin=begin, end=end)
print(events[1].event_minutes_items[4].votes[4].person)
# Person(
#     name='Dan Strauss',
#     email='Dan.Strauss@seattle.gov',
#     ...
# )
```

[seattle-2021-09-14.diff](https://gist.github.com/dphoria/fd949b032596eeb20bda4369324ce406)
