### PR TITLE
bugfix/sanitize-roles

### DIFF
--- a/cdp_scrapers/instances/kingcounty-static.json
+++ b/cdp_scrapers/instances/kingcounty-static.json
@@ -181,7 +181,7 @@
                     "body": "Committee of the Whole",
                     "start_datetime": 1641024000,
                     "end_datetime": 1704009600,
-                    "title": "Chair"
+                    "title": "Council President"
                 }
             ],
             "external_source_id": null
@@ -313,12 +313,6 @@
                     "start_datetime": 1104566400,
                     "end_datetime": 1767168000,
                     "title": "Councilmember"
-                },
-                {
-                    "body": "Committee of the Whole",
-                    "start_datetime": 1641024000,
-                    "end_datetime": 1767168000,
-                    "title": "Vice Chair"
                 }
             ],
             "external_source_id": null

--- a/cdp_scrapers/instances/kingcounty-static.json
+++ b/cdp_scrapers/instances/kingcounty-static.json
@@ -1,4 +1,59 @@
 {
+    "seats" : {
+        "Position 1": {
+            "name": "Position 1",
+            "electoral_area": "Bothell, Kenmore, Shoreline, Woodinville",
+            "image_uri": "https://www.shorelinewa.gov/home/showpublishedimage/9678/637006775507230000"
+        },
+        "Position 2": {
+            "name": "Position 2",
+            "electoral_area": "Eastern Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/NoguchiNeedle_DavidNewman-2-720x313.jpg"
+        },
+        "Position 3": {
+            "name": "Position 3",
+            "electoral_area": "Redmond, Sammamish, Snoqualmie",
+            "image_uri": "https://upload.wikimedia.org/wikipedia/commons/1/16/Bicycle_Capital_of_the_Northwest.JPG"
+        },
+        "Position 4": {
+            "name": "Position 4",
+            "electoral_area": "Western Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/QueenAnne_LempelZiv-720x313.jpg"
+        },
+        "Position 5": {
+            "name": "Position 5",
+            "electoral_area": "Kent, Renton",
+            "image_uri": "https://assets.atlasobscura.com/media/W1siZiIsInVwbG9hZHMvcGxhY2VfaW1hZ2VzL2ViYTUzOWViLTQ4YWQtNGJkMi04ODU1LWE0OGUxMTJmZjYwZWRmM2FmMjRjNDFjOWYwY2YzMV9JTUdfNjI3MC5KUEciXSxbInAiLCJ0aHVtYiIsIjEyMDB4PiJdLFsicCIsImNvbnZlcnQiLCItcXVhbGl0eSA4MSAtYXV0by1vcmllbnQiXV0/IMG_6270.JPG"
+        },
+        "Position 6": {
+            "name": "Position 6",
+            "electoral_area": "Bellevue, Kirkland",
+            "image_uri": "https://bellevuewa.gov/sites/default/files/styles/header_image/public/media/header_image/2019-06/dtp-1600x400.jpg"
+        },
+        "Position 7": {
+            "name": "Position 7",
+            "electoral_area": "Auburn, Federal Way",
+            "image_uri": "https://i.pinimg.com/originals/7c/f0/62/7cf06219cd2967428d796bcba22313d5.jpg"
+        },
+        "Position 8": {
+            "name": "Position 8",
+            "electoral_area": "Burien, Tukwila, West Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/AlkiBeach_NickHallPhotography-720x313.jpg"
+        },
+        "Position 9": {
+            "name": "Position 9",
+            "electoral_area": "Covington, Maple Valley",
+            "image_uri": "https://photos.alltrails.com/eyJidWNrZXQiOiJhc3NldHMuYWxsdHJhaWxzLmNvbSIsImtleSI6InVwbG9hZHMvcGhvdG8vaW1hZ2UvMjM5OTA0NTMvN2ZkYWYzNmEyMjY1YTJlMmMwYWU0M2RiZTQxNGIzMmIuanBnIiwiZWRpdHMiOnsidG9Gb3JtYXQiOiJqcGVnIiwicmVzaXplIjp7IndpZHRoIjoyMDQ4LCJoZWlnaHQiOjIwNDgsImZpdCI6Imluc2lkZSJ9LCJyb3RhdGUiOm51bGwsImpwZWciOnsidHJlbGxpc1F1YW50aXNhdGlvbiI6dHJ1ZSwib3ZlcnNob290RGVyaW5naW5nIjp0cnVlLCJvcHRpbWlzZVNjYW5zIjp0cnVlLCJxdWFudGlzYXRpb25UYWJsZSI6M319fQ=="
+        }
+    },
+    "primary_bodies": {
+        "Metropolitan King County Council": {
+            "name": "Metropolitan King County Council"
+        },
+        "Committee of the Whole": {
+            "name": "Committee of the Whole"
+        }
+    },
     "persons": {
         "Rod Dembowski": {
             "name": "Rod Dembowski",
@@ -8,14 +63,21 @@
             "phone": "206-477-1001",
             "website": "https://kingcounty.gov/council/dembowski.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/Dembowski_2x3_print.ashx",
-            "seat": {
-                "name": "Position 1",
-                "electoral_area": "Bothell, Kenmore, Shoreline, Woodinville",
-                "electoral_type": null,
-                "image_uri": "https://www.shorelinewa.gov/home/showpublishedimage/9678/637006775507230000",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 1",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1357027200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1357027200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Girmay Zahilay": {
@@ -26,14 +88,21 @@
             "phone": "206-477-1002",
             "website": "https://kingcounty.gov/council/zahilay",
             "picture_uri": "https://kingcounty.gov/~/media/council/Zahilay/Zahilay_DSC8834_2x3.ashx",
-            "seat": {
-                "name": "Position 2",
-                "electoral_area": "Eastern Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/NoguchiNeedle_DavidNewman-2-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 2",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1577001600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1577001600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Kathy Lambert": {
@@ -44,14 +113,21 @@
             "phone": "206-477-1003",
             "website": "https://kingcounty.gov/council/lambert",
             "picture_uri": "https://kingcounty.gov/~/media/Lambert/images/2019/Lambert_2020_2x3.ashx",
-            "seat": {
-                "name": "Position 3",
-                "electoral_area": "Redmond, Sammamish, Snoqualmie",
-                "electoral_type": null,
-                "image_uri": "https://upload.wikimedia.org/wikipedia/commons/1/16/Bicycle_Capital_of_the_Northwest.JPG",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 3",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1009872000,
+                    "end_datetime": 1640937600,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1009872000,
+                    "end_datetime": 1640937600,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Sarah Perry": {
@@ -62,14 +138,21 @@
             "phone": "206-477-1003",
             "website": "https://kingcounty.gov/council/perry.aspx",
             "picture_uri": "https://kingcounty.gov/council/~/media/council/perry/KCC_SarahPerry.ashx",
-            "seat": {
-                "name": "Position 3",
-                "electoral_area": "Redmond, Sammamish, Snoqualmie",
-                "electoral_type": null,
-                "image_uri": "https://upload.wikimedia.org/wikipedia/commons/1/16/Bicycle_Capital_of_the_Northwest.JPG",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 3",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Jeanne Kohl-Welles": {
@@ -80,14 +163,27 @@
             "phone": "206-477-1004",
             "website": "https://kingcounty.gov/council/kohl-welles.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/kohl-welles/images/2020/Kohl_Wells_2x3_print.ashx",
-            "seat": {
-                "name": "Position 4",
-                "electoral_area": "Western Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/QueenAnne_LempelZiv-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 4",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1704009600,
+                    "title": "Chair"
+                }
+            ],
             "external_source_id": null
         },
         "Dave Upthegrove": {
@@ -98,14 +194,21 @@
             "phone": "206-477-1005",
             "website": "https://kingcounty.gov/council/upthegrove.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/Upthegove_2x3_print.ashx",
-            "seat": {
-                "name": "Position 5",
-                "electoral_area": "Kent, Renton",
-                "electoral_type": null,
-                "image_uri": "https://assets.atlasobscura.com/media/W1siZiIsInVwbG9hZHMvcGxhY2VfaW1hZ2VzL2ViYTUzOWViLTQ4YWQtNGJkMi04ODU1LWE0OGUxMTJmZjYwZWRmM2FmMjRjNDFjOWYwY2YzMV9JTUdfNjI3MC5KUEciXSxbInAiLCJ0aHVtYiIsIjEyMDB4PiJdLFsicCIsImNvbnZlcnQiLCItcXVhbGl0eSA4MSAtYXV0by1vcmllbnQiXV0/IMG_6270.JPG",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 5",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Claudia Balducci": {
@@ -116,14 +219,27 @@
             "phone": "206-477-1006",
             "website": "https://kingcounty.gov/council/balducci.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/balducci/images/2021/Balducci_highres.ashx",
-            "seat": {
-                "name": "Position 6",
-                "electoral_area": "Bellevue, Kirkland",
-                "electoral_type": null,
-                "image_uri": "https://bellevuewa.gov/sites/default/files/styles/header_image/public/media/header_image/2019-06/dtp-1600x400.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 6",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1767168000,
+                    "title": "Council President"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Pete von Reichbauer": {
@@ -134,14 +250,21 @@
             "phone": "206-477-1007",
             "website": "https://kingcounty.gov/council/vonreichbauer",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/von_Reichbauer_2x3_print.ashx",
-            "seat": {
-                "name": "Position 7",
-                "electoral_area": "Auburn, Federal Way",
-                "electoral_type": null,
-                "image_uri": "https://i.pinimg.com/originals/7c/f0/62/7cf06219cd2967428d796bcba22313d5.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 7",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 757411200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 757411200,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Joe McDermott": {
@@ -152,14 +275,21 @@
             "phone": "206-477-1008",
             "website": "https://kingcounty.gov/council/mcdermott.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/joecropped.ashx",
-            "seat": {
-                "name": "Position 8",
-                "electoral_area": "Burien, Tukwila, West Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/AlkiBeach_NickHallPhotography-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 8",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 757411200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 757411200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                }
+            ],
             "external_source_id": null
         },
         "Reagan Dunn": {
@@ -170,14 +300,27 @@
             "phone": "206-477-1009",
             "website": "https://kingcounty.gov/council/dunn",
             "picture_uri": "https://kingcounty.gov/~/media/Dunn/images/2019/Dunn_DSC8750_2x3.ashx",
-            "seat": {
-                "name": "Position 9",
-                "electoral_area": "Covington, Maple Valley",
-                "electoral_type": null,
-                "image_uri": "https://photos.alltrails.com/eyJidWNrZXQiOiJhc3NldHMuYWxsdHJhaWxzLmNvbSIsImtleSI6InVwbG9hZHMvcGhvdG8vaW1hZ2UvMjM5OTA0NTMvN2ZkYWYzNmEyMjY1YTJlMmMwYWU0M2RiZTQxNGIzMmIuanBnIiwiZWRpdHMiOnsidG9Gb3JtYXQiOiJqcGVnIiwicmVzaXplIjp7IndpZHRoIjoyMDQ4LCJoZWlnaHQiOjIwNDgsImZpdCI6Imluc2lkZSJ9LCJyb3RhdGUiOm51bGwsImpwZWciOnsidHJlbGxpc1F1YW50aXNhdGlvbiI6dHJ1ZSwib3ZlcnNob290RGVyaW5naW5nIjp0cnVlLCJvcHRpbWlzZVNjYW5zIjp0cnVlLCJxdWFudGlzYXRpb25UYWJsZSI6M319fQ==",
-                "external_source_id": null,
-                "roles": null
-            },
+            "seat": "Position 9",
+            "roles": [
+                {
+                    "body": "Metropolitan King County Council",
+                    "start_datetime": 1104566400,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1104566400,
+                    "end_datetime": 1767168000,
+                    "title": "Councilmember"
+                },
+                {
+                    "body": "Committee of the Whole",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1767168000,
+                    "title": "Vice Chair"
+                }
+            ],
             "external_source_id": null
         }
     }

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 
 from cdp_backend.pipeline.ingestion_models import Person, Seat
-from cdp_backend.database.constants import RoleTitle
 from ..legistar_utils import (
     LEGISTAR_EV_SITE_URL,
     LegistarScraper,

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 
 from cdp_backend.pipeline.ingestion_models import Person, Seat
+from cdp_backend.database.constants import RoleTitle
 from ..legistar_utils import (
     LEGISTAR_EV_SITE_URL,
     LegistarScraper,
@@ -61,6 +62,7 @@ class KingCountyScraper(LegistarScraper):
                 "Watch King County TV Channel 22",
             ],
             known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
+            role_replacements={"Boardmember": RoleTitle.MEMBER},
         )
 
     def get_content_uris(self, legistar_ev: Dict) -> List[ContentURIs]:

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -17,7 +17,7 @@ from ..legistar_utils import (
     LegistarScraper,
 )
 from ..scraper_utils import str_simplified
-from ..types import ContentURIs
+from ..types import ContentURIs, ScraperStaticData
 
 ###############################################################################
 
@@ -77,7 +77,7 @@ class KingCountyScraper(LegistarScraper):
                 "This is a mandatory referral to the",
                 "Watch King County TV Channel 22",
             ],
-            known_persons=known_persons,
+            known_static_data=ScraperStaticData(persons=known_persons),
         )
 
     def get_content_uris(self, legistar_ev: Dict) -> List[ContentURIs]:

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -62,7 +62,6 @@ class KingCountyScraper(LegistarScraper):
                 "Watch King County TV Channel 22",
             ],
             known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
-            role_replacements={"Boardmember": RoleTitle.MEMBER},
         )
 
     def get_content_uris(self, legistar_ev: Dict) -> List[ContentURIs]:

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -61,7 +61,7 @@ class KingCountyScraper(LegistarScraper):
                 "This is a mandatory referral to the",
                 "Watch King County TV Channel 22",
             ],
-            known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
+            static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
             role_replacements={
                 "Boardmember": RoleTitle.MEMBER,
                 "Mr.": RoleTitle.MEMBER,

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -16,7 +16,7 @@ from ..legistar_utils import (
     LEGISTAR_EV_SITE_URL,
     LegistarScraper,
 )
-from ..scraper_utils import str_simplified
+from ..scraper_utils import str_simplified, parse_static_file
 from ..types import ContentURIs, ScraperStaticData
 
 ###############################################################################
@@ -27,23 +27,6 @@ log = logging.getLogger(__name__)
 
 STATIC_FILE_KEY_PERSONS = "persons"
 STATIC_FILE_DEFAULT_PATH = Path(__file__).parent / "kingcounty-static.json"
-
-# will be passed into LegistarScraper.__init__()
-# to inject data into Persons to fill in information missing in Legistar API
-known_persons: Optional[Dict[str, Person]] = None
-
-# load long-term static data at file load-time, if file exists
-if Path(STATIC_FILE_DEFAULT_PATH).exists():
-    with open(STATIC_FILE_DEFAULT_PATH, "rb") as json_file:
-        static_data = json.load(json_file)
-
-    known_persons = {}
-    for name, person in static_data[STATIC_FILE_KEY_PERSONS].items():
-        known_persons[name] = Person.from_dict(person)
-
-
-if known_persons:
-    log.debug(f"loaded static data for {', '.join(known_persons.keys())}")
 
 ###############################################################################
 
@@ -77,7 +60,7 @@ class KingCountyScraper(LegistarScraper):
                 "This is a mandatory referral to the",
                 "Watch King County TV Channel 22",
             ],
-            known_static_data=ScraperStaticData(persons=known_persons),
+            known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
         )
 
     def get_content_uris(self, legistar_ev: Dict) -> List[ContentURIs]:

--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -4,7 +4,7 @@
 import logging
 import re
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 from pathlib import Path
@@ -17,7 +17,7 @@ from ..legistar_utils import (
     LegistarScraper,
 )
 from ..scraper_utils import str_simplified, parse_static_file
-from ..types import ContentURIs, ScraperStaticData
+from ..types import ContentURIs
 
 ###############################################################################
 

--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -1,4 +1,41 @@
 {
+    "seats" : {
+        "Mayor": {
+            "name": "Mayor",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/facebook/public/2020-01/city_hall_portland_oregon_2012.jpg"
+        },
+        "Position 1": {
+            "name": "Position 1",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2019-09/aboutbps_0.jpg"
+        },
+        "Position 2": {
+            "name": "Position 2",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020/50094388718_561b442a17_k.jpg"
+        },
+        "Position 3": {
+            "name": "Position 3",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-07/station-1.jpg"
+        },
+        "Position 4": {
+            "name": "Position 4",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-08/environmental-services-program.jpg"
+        },
+        "Auditor": {
+            "name": "Auditor",
+            "electoral_area": "Citywide",
+            "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-08/environmental-services-program.jpg"
+        }
+    },
+    "primary_bodies": {
+        "City Council": {
+            "name": "City Council"
+        }
+    },
     "persons": {
         "Ted Wheeler": {
             "name": "Ted Wheeler",
@@ -8,69 +45,63 @@
             "phone": "503-823-4120",
             "website": "https://www.portland.gov/wheeler",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2020-03/mayor-wheeler-headshot-4x5-3-5-2020.jpg",
-            "seat": {
-                "name": "Mayor",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/facebook/public/2020-01/city_hall_portland_oregon_2012.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Council President",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Council"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Budget"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Management and Finance"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Government Relations"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Attorney"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Police"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Prosper Portland"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Emergency Management"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1483257600,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Equity and Human Rights"}
-                    }
-                ]
-            },
+            "seat": "Mayor",
+            "roles": [
+                {
+                    "title":  "Council President",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": "City Council"
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "City Budget"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Management and Finance"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Government Relations"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "City Attorney"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Police"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Prosper Portland"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Emergency Management"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1483257600,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Equity and Human Rights"}
+                }
+            ],
             "external_source_id": null
         },
         "Carmen Rubio": {
@@ -81,45 +112,39 @@
             "phone": "503-823-3008",
             "website": "https://www.portland.gov/rubio",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/carmen-rubio.jpg",
-            "seat": {
-                "name": "Position 1",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2019-09/aboutbps_0.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Councilmember",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Council"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Parks & Recreation"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Planning and Sustainability"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Community Technology"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Small Donor Elections"}
-                    }
-                ]
-            },
+            "seat": "Position 1",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": "City Council"
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Parks & Recreation"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Planning and Sustainability"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Community Technology"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Small Donor Elections"}
+                }
+            ],
             "external_source_id": null
         },
         "Dan Ryan": {
@@ -130,39 +155,33 @@
             "phone": "503-823-3589",
             "website": "https://www.portland.gov/ryan",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/katalina-berbari-2_0.jpg",
-            "seat": {
-                "name": "Position 2",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020/50094388718_561b442a17_k.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Councilmember",
-                        "start_datetime": 1599721200,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "City Council"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1599721200,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Development Services (BDS)"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1599721200,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Housing Bureau"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1599721200,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Children's Levy"}
-                    }
-                ]
-            },
+            "seat": "Position 2",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1599721200,
+                    "end_datetime": 1672473600,
+                    "body": "City Council"
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1599721200,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Development Services (BDS)"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1599721200,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Housing Bureau"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1599721200,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Children's Levy"}
+                }
+            ],
             "external_source_id": null
         },
         "Jo Ann Hardesty": {
@@ -173,45 +192,39 @@
             "phone": "503-823-4151",
             "website": "https://www.portland.gov/hardesty",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/max_540w/public/2020-01/jo-ann-hardesty-portrait-about-page.jpg",
-            "seat": {
-                "name": "Position 3",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-07/station-1.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Councilmember",
-                        "start_datetime": 1546329600,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "City Council"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1546329600,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Transportation"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1546329600,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Office of Community & Civic Life"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1546329600,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Portland Fire & Rescue"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1546329600,
-                        "end_datetime": 1672473600,
-                        "body": {"name": "Fire and Police Disability and Retirement"}
-                    }
-                ]
-            },
+            "seat": "Position 3",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1546329600,
+                    "end_datetime": 1672473600,
+                    "body": "City Council"
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1546329600,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Transportation"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1546329600,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Office of Community & Civic Life"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1546329600,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Portland Fire & Rescue"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1546329600,
+                    "end_datetime": 1672473600,
+                    "body": {"name": "Fire and Police Disability and Retirement"}
+                }
+            ],
             "external_source_id": null
         },
         "Mingus Mapps": {
@@ -222,39 +235,33 @@
             "phone": "503-823-4682",
             "website": "https://www.portland.gov/mapps",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/minguswattributionjpegcrop2_0.jpg",
-            "seat": {
-                "name": "Position 4",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-08/environmental-services-program.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Councilmember",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Council"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Water"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Environmental Services"}
-                    },
-                    {
-                        "title":  "Member",
-                        "start_datetime": 1609488000,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "Emergency Communications (9-1-1)"}
-                    }
-                ]
-            },
+            "seat": "Position 4",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": "City Council"
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Water"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Environmental Services"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1609488000,
+                    "end_datetime": 1735632000,
+                    "body": {"name": "Emergency Communications (9-1-1)"}
+                }
+            ],
             "external_source_id": null
         },
         "Mary Hull Caballero": {
@@ -265,21 +272,15 @@
             "phone": "503-823-4078",
             "website": "https://www.portland.gov/auditor/hull-caballero",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_640w/public/2021/mary-hull-caballero_headshot.jpg",
-            "seat": {
-                "name": "Auditor",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-08/environmental-services-program.jpg",
-                "external_source_id": null,
-                "roles": [
-                    {
-                        "title":  "Councilmember",
-                        "start_datetime": 1420099200,
-                        "end_datetime": 1735632000,
-                        "body": {"name": "City Council"}
-                    }
-                ]
-            },
+            "seat": "Auditor",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1420099200,
+                    "end_datetime": 1672473600,
+                    "body": "City Council"
+                }
+            ],
             "external_source_id": null
         }
     }

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -1,9 +1,8 @@
-import json
 import logging
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, List, NamedTuple, Optional, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -25,7 +24,12 @@ from cdp_backend.pipeline.ingestion_models import (
     Vote,
 )
 
-from ..scraper_utils import IngestionModelScraper, reduced_list, str_simplified
+from ..scraper_utils import (
+    IngestionModelScraper,
+    reduced_list,
+    str_simplified,
+    parse_static_file,
+)
 
 ###############################################################################
 
@@ -33,22 +37,7 @@ log = logging.getLogger(__name__)
 
 ###############################################################################
 
-STATIC_FILE_KEY_PERSONS = "persons"
-STATIC_FILE_DEFAULT_PATH = Path(__file__).parent / "portland-static.json"
-
-known_persons: Dict[str, Person] = {}
-
-# load long-term static data at file load-time
-if Path(STATIC_FILE_DEFAULT_PATH).exists():
-    with open(STATIC_FILE_DEFAULT_PATH, "rb") as json_file:
-        static_data = json.load(json_file)
-
-    for name, person in static_data[STATIC_FILE_KEY_PERSONS].items():
-        known_persons[name] = Person.from_dict(person)
-
-
-if len(known_persons) > 0:
-    log.debug(f"loaded static data for {', '.join(known_persons.keys())}")
+SCRAPER_STATIC_DATA = parse_static_file(Path(__file__).parent / "portland-static.json")
 
 ###############################################################################
 
@@ -232,10 +221,10 @@ class PortlandScraper(IngestionModelScraper):
         ----------
         portland-static.json
         """
-        if name not in known_persons:
+        if name not in SCRAPER_STATIC_DATA.persons:
             raise KeyError(f"{name} is unknown. Please update portland-static.json")
 
-        return known_persons[name]
+        return SCRAPER_STATIC_DATA.persons[name]
 
     def get_matter(self, minute_section: Tag) -> Optional[Matter]:
         """

--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -63,20 +63,19 @@
             "phone": "206-684-8804",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Pedersen/Councilmember-Alex-Pedersen_square-headshot.jpg",
+            "seat": "Position 4",
             "roles": [
                 {
-                    "seat": "Position 4",
                     "body": "City Council",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 4",
                     "body": "Council Briefing",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -88,20 +87,19 @@
             "phone": "206-684-8807",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Lewis/Andrew-Lewis-Campaign-Headshot_300x300.jpg",
+            "seat": "Position 7",
             "roles": [
                 {
-                    "seat": "Position 7",
                     "body": "City Council",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 7",
                     "body": "Council Briefing",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -113,20 +111,19 @@
             "phone": "206-684-8806",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Strauss/strauss_headshot_300x300.jpg",
+            "seat": "Position 6",
             "roles": [
                 {
-                    "seat": "Position 6",
                     "body": "City Council",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 6",
                     "body": "Council Briefing",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -138,34 +135,31 @@
             "phone": "206-684-8805",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Juarez/Debora-Juarez-2018_225x225.jpg",
+            "seat": "Position 5",
             "roles": [
                 {
-                    "seat": "Position 5",
                     "body": "City Council",
                     "start_datetime": 1451635200,
                     "end_datetime": 1640937600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 5",
                     "body": "City Council",
                     "start_datetime": 1641024000,
                     "end_datetime": 1704009600,
                     "title": "Council President"
                 },
                 {
-                    "seat": "Position 5",
                     "body": "Council Briefing",
                     "start_datetime": 1451635200,
                     "end_datetime": 1640937600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 5",
                     "body": "Council Briefing",
                     "start_datetime": 1641024000,
                     "end_datetime": 1704009600,
-                    "title": "Chair"
+                    "title": "Council President"
                 }
             ]
         },
@@ -177,20 +171,19 @@
             "phone": "206-684-8803",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Sawant/Sawant_225x225.jpg",
+            "seat": "Position 3",
             "roles": [
                 {
-                    "seat": "Position 3",
                     "body": "City Council",
                     "start_datetime": 1388563200,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 3",
                     "body": "Council Briefing",
                     "start_datetime": 1388563200,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -202,54 +195,50 @@
             "phone": null,
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Herbold/Herbold_225x225.jpg",
+            "seat": "Position 1",
             "roles": [
                 {
-                    "seat": "Position 1",
                     "body": "City Council",
                     "start_datetime": 1451635200,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 1",
                     "body": "Council Briefing",
                     "start_datetime": 1451635200,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
         "M. Lorena Gonz\u00e1lez": {
             "name": "M. Lorena Gonz\u00e1lez",
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Gonzalez/Lorena-González_2020-headshot_225x225.jpg",
+            "seat": "Position 9",
             "roles": [
                 {
-                    "seat": "Position 9",
                     "body": "City Council",
                     "start_datetime": 1448352000,
                     "end_datetime": 1577779200,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 9",
                     "body": "City Council",
                     "start_datetime": 1577865600,
                     "end_datetime": 1640937600,
                     "title": "Council President"
                 },
                 {
-                    "seat": "Position 9",
                     "body": "Council Briefing",
                     "start_datetime": 1448352000,
                     "end_datetime": 1577779200,
-                    "title": "Member"
+                    "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 9",
                     "body": "Council Briefing",
                     "start_datetime": 1577865600,
                     "end_datetime": 1640937600,
-                    "title": "Chair"
+                    "title": "Council President"
                 }
             ]
         },
@@ -261,20 +250,19 @@
             "phone": "206-684-8809",
             "website": null,
             "picture_uri": "https://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
+            "seat": "Position 9",
             "roles": [
                 {
-                    "seat": "Position 9",
                     "body": "City Council",
                     "start_datetime": 1641024000,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 9",
                     "body": "Council Briefing",
                     "start_datetime": 1641024000,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -286,20 +274,19 @@
             "phone": "206-684-8802",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Morales/Tammy-Morales_headshot_final_300x300.jpg",
+            "seat": "Position 2",
             "roles": [
                 {
-                    "seat": "Position 2",
                     "body": "City Council",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 2",
                     "body": "Council Briefing",
                     "start_datetime": 1577865600,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         },
@@ -311,20 +298,19 @@
             "phone": "206-684-8808",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Mosqueda/Mosqueda_225x225.jpg",
+            "seat": "Position 8",
             "roles": [
                 {
-                    "seat": "Position 8",
                     "body": "City Council",
                     "start_datetime": 1511856000,
                     "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
-                    "seat": "Position 8",
                     "body": "Council Briefing",
                     "start_datetime": 1511856000,
                     "end_datetime": 1704009600,
-                    "title": "Member"
+                    "title": "Councilmember"
                 }
             ]
         }

--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -140,7 +140,7 @@
                 {
                     "body": "City Council",
                     "start_datetime": 1451635200,
-                    "end_datetime": 1640937600,
+                    "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
@@ -152,7 +152,7 @@
                 {
                     "body": "Council Briefing",
                     "start_datetime": 1451635200,
-                    "end_datetime": 1640937600,
+                    "end_datetime": 1704009600,
                     "title": "Councilmember"
                 },
                 {
@@ -219,7 +219,7 @@
                 {
                     "body": "City Council",
                     "start_datetime": 1448352000,
-                    "end_datetime": 1577779200,
+                    "end_datetime": 1640937600,
                     "title": "Councilmember"
                 },
                 {
@@ -231,7 +231,7 @@
                 {
                     "body": "Council Briefing",
                     "start_datetime": 1448352000,
-                    "end_datetime": 1577779200,
+                    "end_datetime": 1640937600,
                     "title": "Councilmember"
                 },
                 {

--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -1,4 +1,59 @@
 {
+    "seats" : {
+        "Position 1": {
+            "name": "Position 1",
+            "electoral_area": "West Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/AlkiBeach_NickHallPhotography-720x313.jpg"
+        },
+        "Position 2": {
+            "name": "Position 2",
+            "electoral_area": "Southeast Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/Safeco_DavidNewman-720x313.jpg"
+        },
+        "Position 3": {
+            "name": "Position 3",
+            "electoral_area": "Central Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/NoguchiNeedle_DavidNewman-2-720x313.jpg"
+        },
+        "Position 4": {
+            "name": "Position 4",
+            "electoral_area": "Northeast Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/Suzzallo_Reading_Room_NicholasBoos-720x313.jpg"
+        },
+        "Position 5": {
+            "name": "Position 5",
+            "electoral_area": "North Seattle",
+            "image_uri": "https://www.seattle.gov/images/Departments/SDOT/BridgeStairsProgram/AerialRendering_2020.jpg"
+        },
+        "Position 6": {
+            "name": "Position 6",
+            "electoral_area": "Northwest Seattle",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/BallardFarmersMarket_kallu-2-720x313.jpg"
+        },
+        "Position 7": {
+            "name": "Position 7",
+            "electoral_area": "Pioneer Square to Magnolia",
+            "image_uri": "https://uploads.visitseattle.org/2015/03/QueenAnne_LempelZiv-720x313.jpg"
+        },
+        "Position 8": {
+            "name": "Position 8",
+            "electoral_area": "Citywide",
+            "image_uri": "https://upload.wikimedia.org/wikipedia/commons/3/36/SeattleI5Skyline.jpg"
+        },
+        "Position 9": {
+            "name": "Position 9",
+            "electoral_area": "Citywide",
+            "image_uri": "https://upload.wikimedia.org/wikipedia/commons/3/36/SeattleI5Skyline.jpg"
+        }
+    },
+    "primary_bodies": {
+        "City Council": {
+            "name": "City Council"
+        },
+        "Council Briefing": {
+            "name": "Council Briefing"
+        }
+    },
     "persons": {
         "Alex Pedersen": {
             "name": "Alex Pedersen",
@@ -8,15 +63,22 @@
             "phone": "206-684-8804",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Pedersen/Councilmember-Alex-Pedersen_square-headshot.jpg",
-            "seat": {
-                "name": "Position 4",
-                "electoral_area": "Northeast Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/Suzzallo_Reading_Room_NicholasBoos-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 4",
+                    "body": "City Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 4",
+                    "body": "Council Briefing",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Andrew Lewis": {
             "name": "Andrew Lewis",
@@ -26,15 +88,22 @@
             "phone": "206-684-8807",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Lewis/Andrew-Lewis-Campaign-Headshot_300x300.jpg",
-            "seat": {
-                "name": "Position 7",
-                "electoral_area": "Pioneer Square to Magnolia",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/QueenAnne_LempelZiv-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 7",
+                    "body": "City Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 7",
+                    "body": "Council Briefing",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Dan Strauss": {
             "name": "Dan Strauss",
@@ -44,15 +113,22 @@
             "phone": "206-684-8806",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Strauss/strauss_headshot_300x300.jpg",
-            "seat": {
-                "name": "Position 6",
-                "electoral_area": "Northwest Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/BallardFarmersMarket_kallu-2-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 6",
+                    "body": "City Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 6",
+                    "body": "Council Briefing",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Debora Juarez": {
             "name": "Debora Juarez",
@@ -62,15 +138,36 @@
             "phone": "206-684-8805",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Juarez/Debora-Juarez-2018_225x225.jpg",
-            "seat": {
-                "name": "Position 5",
-                "electoral_area": "North Seattle",
-                "electoral_type": null,
-                "image_uri": "https://www.seattle.gov/images/Departments/SDOT/BridgeStairsProgram/AerialRendering_2020.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 5",
+                    "body": "City Council",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1640937600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 5",
+                    "body": "City Council",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1704009600,
+                    "title": "Council President"
+                },
+                {
+                    "seat": "Position 5",
+                    "body": "Council Briefing",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1640937600,
+                    "title": "Member"
+                },
+                {
+                    "seat": "Position 5",
+                    "body": "Council Briefing",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1704009600,
+                    "title": "Chair"
+                }
+            ]
         },
         "Kshama Sawant": {
             "name": "Kshama Sawant",
@@ -80,15 +177,22 @@
             "phone": "206-684-8803",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Sawant/Sawant_225x225.jpg",
-            "seat": {
-                "name": "Position 3",
-                "electoral_area": "Central Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/NoguchiNeedle_DavidNewman-2-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 3",
+                    "body": "City Council",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 3",
+                    "body": "Council Briefing",
+                    "start_datetime": 1388563200,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Lisa Herbold": {
             "name": "Lisa Herbold",
@@ -98,33 +202,56 @@
             "phone": null,
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Herbold/Herbold_225x225.jpg",
-            "seat": {
-                "name": "Position 1",
-                "electoral_area": "West Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/AlkiBeach_NickHallPhotography-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 1",
+                    "body": "City Council",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 1",
+                    "body": "Council Briefing",
+                    "start_datetime": 1451635200,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "M. Lorena Gonz\u00e1lez": {
             "name": "M. Lorena Gonz\u00e1lez",
-            "is_active": false,
-            "router_string": null,
-            "email": null,
-            "phone": null,
-            "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Gonzalez/Lorena-González_2020-headshot_225x225.jpg",
-            "seat": {
-                "name": "Position 9",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://upload.wikimedia.org/wikipedia/commons/3/36/SeattleI5Skyline.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 9",
+                    "body": "City Council",
+                    "start_datetime": 1448352000,
+                    "end_datetime": 1577779200,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 9",
+                    "body": "City Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1640937600,
+                    "title": "Council President"
+                },
+                {
+                    "seat": "Position 9",
+                    "body": "Council Briefing",
+                    "start_datetime": 1448352000,
+                    "end_datetime": 1577779200,
+                    "title": "Member"
+                },
+                {
+                    "seat": "Position 9",
+                    "body": "Council Briefing",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1640937600,
+                    "title": "Chair"
+                }
+            ]
         },
         "Sara Nelson": {
             "name": "Sara Nelson",
@@ -134,15 +261,22 @@
             "phone": "206-684-8809",
             "website": null,
             "picture_uri": "https://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
-            "seat": {
-                "name": "Position 9",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://upload.wikimedia.org/wikipedia/commons/3/36/SeattleI5Skyline.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 9",
+                    "body": "City Council",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 9",
+                    "body": "Council Briefing",
+                    "start_datetime": 1641024000,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Tammy J. Morales": {
             "name": "Tammy J. Morales",
@@ -152,15 +286,22 @@
             "phone": "206-684-8802",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Morales/Tammy-Morales_headshot_final_300x300.jpg",
-            "seat": {
-                "name": "Position 2",
-                "electoral_area": "Southeast Seattle",
-                "electoral_type": null,
-                "image_uri": "https://uploads.visitseattle.org/2015/03/Safeco_DavidNewman-720x313.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 2",
+                    "body": "City Council",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 2",
+                    "body": "Council Briefing",
+                    "start_datetime": 1577865600,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         },
         "Teresa Mosqueda": {
             "name": "Teresa Mosqueda",
@@ -170,15 +311,22 @@
             "phone": "206-684-8808",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Mosqueda/Mosqueda_225x225.jpg",
-            "seat": {
-                "name": "Position 8",
-                "electoral_area": "Citywide",
-                "electoral_type": null,
-                "image_uri": "https://upload.wikimedia.org/wikipedia/commons/3/36/SeattleI5Skyline.jpg",
-                "external_source_id": null,
-                "roles": null
-            },
-            "external_source_id": null
+            "roles": [
+                {
+                    "seat": "Position 8",
+                    "body": "City Council",
+                    "start_datetime": 1511856000,
+                    "end_datetime": 1704009600,
+                    "title": "Councilmember"
+                },
+                {
+                    "seat": "Position 8",
+                    "body": "Council Briefing",
+                    "start_datetime": 1511856000,
+                    "end_datetime": 1704009600,
+                    "title": "Member"
+                }
+            ]
         }
     }
 }

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -593,5 +593,7 @@ class SeattleScraper(LegistarScraper):
             return False
 
         with open(file_path, "wt") as dump:
-            dump.write(json.dumps({STATIC_FILE_KEY_PERSONS: static_person_info}, indent=4))
+            dump.write(
+                json.dumps({STATIC_FILE_KEY_PERSONS: static_person_info}, indent=4)
+            )
         return True

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -29,11 +29,9 @@ log = logging.getLogger(__name__)
 
 ###############################################################################
 
+STATIC_FILE_KEY_PERSONS = "persons"
 STATIC_FILE_DEFAULT_PATH = Path(__file__).parent / "seattle-static.json"
-if STATIC_FILE_DEFAULT_PATH.exists():
-    SCRAPER_STATIC_DATA = parse_static_file(STATIC_FILE_DEFAULT_PATH)
-else:
-    SCRAPER_STATIC_DATA = None
+
 # we have discovered the city clerk accidentally entered Daniel Strauss
 # instead of the correct Dan Strauss for a few events
 PERSON_ALIASES = {"Dan Strauss": set(["Daniel Strauss"])}
@@ -67,7 +65,7 @@ class SeattleScraper(LegistarScraper):
                 r".+:$",
                 "Pursuant to Washington State",
             ],
-            known_static_data=SCRAPER_STATIC_DATA,
+            known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
             person_aliases=PERSON_ALIASES,
         )
 
@@ -595,5 +593,5 @@ class SeattleScraper(LegistarScraper):
             return False
 
         with open(file_path, "wt") as dump:
-            dump.write(json.dumps({"persons": static_person_info}, indent=4))
+            dump.write(json.dumps({STATIC_FILE_KEY_PERSONS: static_person_info}, indent=4))
         return True

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -68,7 +68,7 @@ class SeattleScraper(LegistarScraper):
                 r".+:$",
                 "Pursuant to Washington State",
             ],
-            known_static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
+            static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
             person_aliases=PERSON_ALIASES,
         )
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from copy import deepcopy
 import logging
 import re
 from datetime import datetime, timedelta
@@ -1250,7 +1251,7 @@ class LegistarScraper(IngestionModelScraper):
         scraper_utils.sanitize_roles()
         """
         try:
-            known_person = self.known_static_data.persons[person.name]
+            known_person = deepcopy(self.known_static_data.persons[person.name])
         except (AttributeError, KeyError):
             return person
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -445,6 +445,11 @@ class LegistarScraper(IngestionModelScraper):
         Dictionary used to catch name aliases
         and resolve improperly unique Persons to the one correct Person.
         Default: None
+    role_replacements: Optional[Dict[str, str]]
+        Dictionary used to replace role titles with CDP standard role titles.
+        The keys should be titles you want to replace and the values should be a
+        CDP standard role.
+        Default: None
 
     See Also
     --------
@@ -471,6 +476,7 @@ class LegistarScraper(IngestionModelScraper):
         minutes_item_decision_failed_pattern: str = r"not|fail",
         known_static_data: Optional[ScraperStaticData] = None,
         person_aliases: Optional[Dict[str, Set[str]]] = None,
+        role_replacements: Optional[Dict[str, str]] = None,
     ):
         super().__init__(timezone=timezone, person_aliases=person_aliases)
 
@@ -498,6 +504,7 @@ class LegistarScraper(IngestionModelScraper):
         )
 
         self.known_static_data = known_static_data
+        self.role_replacements = role_replacements or {}
 
     def get_matter_status(self, legistar_matter_status: str) -> Optional[str]:
         """
@@ -730,6 +737,29 @@ class LegistarScraper(IngestionModelScraper):
             )
         )
 
+    def use_or_replace_role(self, role_title: str) -> str:
+        """
+        Lookup if the provided role title should be replaced with a CDP standard value.
+        If the provided role title should be replaced, then return the proper
+        replacement title, otherwise if the title wasn't found in the role replacement
+        lookup table, return the provided role_title unchanged.
+
+        Parameters
+        ----------
+        role_title: str
+            The role title to check and potentially replace with a CDP standard.
+
+        Returns
+        -------
+        role_title: str
+            The original role title if no replacement was found in the role replacements
+            lookup-table, or the CDP standard title swapped from the lookup-table.
+        """
+        if role_title in self.role_replacements:
+            return self.role_replacements[role_title]
+
+        return role_title
+
     def get_roles(
         self, legistar_office_records: List[Dict[str, Any]]
     ) -> Optional[List[Role]]:
@@ -774,7 +804,7 @@ class LegistarScraper(IngestionModelScraper):
                             )
                         ),
                         external_source_id=str(record[LEGISTAR_ROLE_EXT_ID]),
-                        title=(
+                        title=self.use_or_replace_role(
                             str_simplified(record[LEGISTAR_ROLE_TITLE])
                             or str_simplified(record[LEGISTAR_ROLE_TITLE_ALT])
                         ),

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -445,11 +445,6 @@ class LegistarScraper(IngestionModelScraper):
         Dictionary used to catch name aliases
         and resolve improperly unique Persons to the one correct Person.
         Default: None
-    role_replacements: Optional[Dict[str, str]]
-        Dictionary used to replace role titles with CDP standard role titles.
-        The keys should be titles you want to replace and the values should be a
-        CDP standard role.
-        Default: None
 
     See Also
     --------
@@ -476,7 +471,6 @@ class LegistarScraper(IngestionModelScraper):
         minutes_item_decision_failed_pattern: str = r"not|fail",
         known_static_data: Optional[ScraperStaticData] = None,
         person_aliases: Optional[Dict[str, Set[str]]] = None,
-        role_replacements: Optional[Dict[str, str]] = None,
     ):
         super().__init__(timezone=timezone, person_aliases=person_aliases)
 
@@ -504,7 +498,6 @@ class LegistarScraper(IngestionModelScraper):
         )
 
         self.known_static_data = known_static_data
-        self.role_replacements = role_replacements or {}
 
     def get_matter_status(self, legistar_matter_status: str) -> Optional[str]:
         """
@@ -737,29 +730,6 @@ class LegistarScraper(IngestionModelScraper):
             )
         )
 
-    def use_or_replace_role(self, role_title: str) -> str:
-        """
-        Lookup if the provided role title should be replaced with a CDP standard value.
-        If the provided role title should be replaced, then return the proper
-        replacement title, otherwise if the title wasn't found in the role replacement
-        lookup table, return the provided role_title unchanged.
-
-        Parameters
-        ----------
-        role_title: str
-            The role title to check and potentially replace with a CDP standard.
-
-        Returns
-        -------
-        role_title: str
-            The original role title if no replacement was found in the role replacements
-            lookup-table, or the CDP standard title swapped from the lookup-table.
-        """
-        if role_title in self.role_replacements:
-            return self.role_replacements[role_title]
-
-        return role_title
-
     def get_roles(
         self, legistar_office_records: List[Dict[str, Any]]
     ) -> Optional[List[Role]]:
@@ -804,7 +774,7 @@ class LegistarScraper(IngestionModelScraper):
                             )
                         ),
                         external_source_id=str(record[LEGISTAR_ROLE_EXT_ID]),
-                        title=self.use_or_replace_role(
+                        title=(
                             str_simplified(record[LEGISTAR_ROLE_TITLE])
                             or str_simplified(record[LEGISTAR_ROLE_TITLE_ALT])
                         ),

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1251,7 +1251,7 @@ class LegistarScraper(IngestionModelScraper):
         scraper_utils.sanitize_roles()
         """
         try:
-            known_person = deepcopy(self.static_data.persons[person.name])
+            known_person = self.static_data.persons[person.name]
         except (AttributeError, KeyError):
             return person
 
@@ -1259,7 +1259,7 @@ class LegistarScraper(IngestionModelScraper):
             static_info = getattr(known_person, attr)
             if static_info is not None:
                 # have long-term information provided in "static*.json"
-                setattr(person, attr, static_info)
+                setattr(person, attr, deepcopy(static_info))
 
         # now that we have seat from static hard-coded data
         # we can bring in seat.roles (OfficeRecords from Legistar API)

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -743,29 +743,31 @@ class LegistarScraper(IngestionModelScraper):
         if not legistar_office_records:
             return None
 
-        return reduced_list(
-            [
-                self.get_none_if_empty(
-                    Role(
-                        body=self.get_body(record[LEGISTAR_ROLE_BODY]),
-                        # e.g. 2017-11-30T00:00:00
-                        start_datetime=self.localize_datetime(
-                            datetime.strptime(
-                                record[LEGISTAR_ROLE_START],
-                                LEGISTAR_DATETIME_FORMAT,
-                            )
-                        ),
-                        end_datetime=self.localize_datetime(
-                            datetime.strptime(
-                                record[LEGISTAR_ROLE_END], LEGISTAR_DATETIME_FORMAT
-                            )
-                        ),
-                        external_source_id=str(record[LEGISTAR_ROLE_EXT_ID]),
-                        title=str_simplified(record[LEGISTAR_ROLE_TITLE]),
+        return self.sanitize_roles(
+            reduced_list(
+                [
+                    self.get_none_if_empty(
+                        Role(
+                            body=self.get_body(record[LEGISTAR_ROLE_BODY]),
+                            # e.g. 2017-11-30T00:00:00
+                            start_datetime=self.localize_datetime(
+                                datetime.strptime(
+                                    record[LEGISTAR_ROLE_START],
+                                    LEGISTAR_DATETIME_FORMAT,
+                                )
+                            ),
+                            end_datetime=self.localize_datetime(
+                                datetime.strptime(
+                                    record[LEGISTAR_ROLE_END], LEGISTAR_DATETIME_FORMAT
+                                )
+                            ),
+                            external_source_id=str(record[LEGISTAR_ROLE_EXT_ID]),
+                            title=str_simplified(record[LEGISTAR_ROLE_TITLE]),
+                        )
                     )
-                )
-                for record in legistar_office_records
-            ]
+                    for record in legistar_office_records
+                ]
+            )
         )
 
     def resolve_person_alias(self, person: Person) -> Optional[Person]:

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -106,7 +106,10 @@ def parse_static_person(
     person.seat.roles = []
 
     for role_json in person_json["roles"]:
-        if role_json["body"] not in primary_bodies:
+        if (
+            isinstance(role_json["body"], str)
+            and role_json["body"] not in primary_bodies
+        ):
             log.error(
                 f"{role_json} is ignored. "
                 f"{role_json['body']} is not defined in top-level 'primary_bodies'"
@@ -117,11 +120,14 @@ def parse_static_person(
                 f"{role_json['title']} is not a RoleTitle constant."
             )
         else:
-            body = primary_bodies[role_json["body"]]
             role: Role = Role.from_dict(
                 {k: v for k, v in role_json.items() if k != "body"}
             )
-            role.body = body
+            if isinstance(role_json["body"], str):
+                role.body = primary_bodies[role_json["body"]]
+            else:
+                role.body = Body.from_dict(role_json["body"])
+
             person.seat.roles.append(role)
 
     return person

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -155,9 +155,115 @@ def parse_static_file(file_path: Path) -> ScraperStaticData:
                 for person_name, person in static_json["persons"].items()
             }
 
+        log.debug(
+            f"ScraperStaticData parsed from {file_path}:\n"
+            f"    seats: {list(seats.keys())}\n"
+            f"    primary_bodies: {list(primary_bodies.keys())}\n"
+            f"    persons: {list(known_persons.keys())}\n"
+        )
         return ScraperStaticData(
             seats=seats, primary_bodies=primary_bodies, persons=known_persons
         )
+
+
+def sanitize_roles(
+    person_name: str,
+    roles: Optional[List[Role]] = None,
+    known_static_data: Optional[ScraperStaticData] = None,
+    president_patterns: List[str] = ["chair", "pres", "super"],
+) -> Optional[List[Role]]:
+    """
+    1. Standardize roles[i].title to RoleTitle constants
+    2. Ensure only 1 councilmember Role per term
+
+    Parameters
+    ----------
+    person_name: str
+        Sanitization target Person.name
+
+    roles: Optional[List[Role]] = None
+        target Person's Roles to sanitize
+
+    known_static_data: Optional[ScraperStaticData]
+        Static data defining primary council bodies and predefined Person.seat.roles.
+        See Notes.
+
+    president_patterns: List[str]
+        roles[i].title = "Council President" or "Chair" if match
+
+    Notes
+    -----
+    Remove roles[#] if roles[#].body in static_data.primary_bodies.
+    Use known_static_data.persons[#].seat.roles instead.
+
+    If roles[i].body not in static_data.primary_bodies,
+    roles[i].title cannot be "Councilmember" or "Council President".
+
+    Use "City Council" and "Council Briefing"
+    if known_static_data.primary_bodies is empty.
+    """
+    if roles is None:
+        roles = []
+
+    if not known_static_data or not known_static_data.primary_bodies:
+        primary_body_names = ["city council", "city briefing"]
+    else:
+        primary_body_names = [
+            body_name.lower() for body_name in known_static_data.primary_bodies.keys()
+        ]
+
+    try:
+        have_primary_roles = len(known_static_data.persons[person_name].seat.roles) > 0
+    except (KeyError, AttributeError, TypeError):
+        have_primary_roles = False
+
+    class CouncilMemberTerm(NamedTuple):
+        start_datetime: datetime
+        end_datetime: datetime
+        roles_index: int
+
+    terms: List[CouncilMemberTerm] = []
+
+    for i, role in enumerate(roles):
+        role_title = str_simplified(role.title).lower()
+
+        if str_simplified(role.body.name).lower() in primary_body_names:
+            if have_primary_roles:
+                roles[i] = None
+            elif re.search("|".join(president_patterns), role_title, re.I) is not None:
+                role.title = RoleTitle.COUNCILPRESIDENT
+            else:
+                role.title = RoleTitle.COUNCILMEMBER
+                # get all councilmember terms
+                if role.start_datetime is not None and role.end_datetime is not None:
+                    terms.append(
+                        CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
+                    )
+        elif "vice" in role_title:
+            role.title = RoleTitle.VICE_CHAIR
+        elif re.search("|".join(president_patterns), role_title, re.I) is not None:
+            role.title = RoleTitle.CHAIR
+        elif "alt" in role_title:
+            role.title = RoleTitle.ALTERNATE
+        else:
+            role.title = RoleTitle.MEMBER
+
+    if have_primary_roles:
+        roles.extend(known_static_data.persons[person_name].seat.roles)
+    if len(terms) == 0:
+        return reduced_list(roles)
+
+    # sort in asc order of start_datetime and end_datetime.
+    terms.sort()
+    # if term i overlaps with term j, end term i before term j
+    for i, term in enumerate(terms[:-1]):
+        if terms[i].end_datetime > terms[i + 1].start_datetime:
+            # reflect adjusted role end date in the actual roles list
+            roles[terms[i].roles_index].end_datetime = terms[
+                i + 1
+            ].start_datetime - timedelta(days=1)
+
+    return reduced_list(roles)
 
 
 class IngestionModelScraper:
@@ -363,128 +469,3 @@ class IngestionModelScraper:
         instances.seattle.person_aliases
         """
         return person
-
-    def sanitize_roles(
-        self,
-        roles: Optional[List[Role]],
-        chair_aliases: Optional[List[str]] = None,
-        council_member_aliases: Optional[List[str]] = None,
-        council_president_aliases: Optional[List[str]] = None,
-    ) -> Optional[List[Role]]:
-        """
-        1. Standardize Role.title to preset strings
-        2. Ensure only 1 councilmember Role per term
-
-        Parameters
-        ----------
-        roles: Optional[List[Role]]
-            Person.seat.roles
-
-        chair_aliases: Optional[List[str]]
-            Role.title becomes "Chair" if includes any string in this list
-
-        council_member_aliases: Optional[List[str]]
-            Role.title becomes "Councilmember" if includes any string in this list
-
-        council_president_aliases: Optional[List[str]]
-            Role.title becomes "Council President" if includes any string in this list
-
-        Returns
-        -------
-        roles: Optional[List[Role]]
-            Role.title standardized and Role.end_datetime adjusted as necessary
-            such that "Councilmember" roles have non-overlapping start_/end_datetime
-        """
-        if not roles:
-            return roles
-
-        if not chair_aliases:
-            chair_aliases = "(chair)|(supervisor)"
-        else:
-            # (chair)|(supervisor)|(foo)|(bar)
-            chair_aliases = f"(chair)|(supervisor)|({')|('.join(chair_aliases)})"
-
-        if not council_member_aliases:
-            council_member_aliases = "council.*member"
-        else:
-            council_president_aliases = (
-                f"(council.*member)|({')|('.join(council_president_aliases)})"
-            )
-
-        if not council_president_aliases:
-            council_president_aliases = "president"
-        else:
-            council_president_aliases = (
-                f"(president)|({')|('.join(council_president_aliases)})"
-            )
-
-        class StdTitles(NamedTuple):
-            title: str
-            pattern: str
-
-        # std role names and patterns to use to match
-        # NOTE: TODO: will use cdp_backend.databse.constants.RoleTitle
-        # when we get a new cdp_backend release
-        std_titles: List[StdTitles] = [
-            # search in this order, e.g. look for vice chair before chair
-            # i.e. more specific search tokens first
-            StdTitles("Vice Chair", "vice.*chair"),
-            StdTitles("Chair", chair_aliases),
-            StdTitles("Councilmember", council_member_aliases),
-            StdTitles("Member", "member"),
-            StdTitles("Council President", council_president_aliases),
-            StdTitles("Alternate", "alternate"),
-        ]
-
-        class CouncilMemberTerm(NamedTuple):
-            start_datetime: datetime
-            end_datetime: datetime
-            roles_index: int
-
-        terms: List[CouncilMemberTerm] = []
-
-        for i, role in enumerate(roles):
-            # standardize e.g. "council member" -> "Councilmember"
-            for std_title in std_titles:
-                if re.search(std_title.pattern, str_simplified(roles[i].title), re.I):
-                    roles[i].title = std_title.title
-                    if roles[i].body is None:
-                        break
-
-                    if str_simplified(roles[i].body.name).lower().endswith("council"):
-                        if roles[i].title == "Member":
-                            # use "councilmember" for city council member role
-                            roles[i].title = "Councilmember"
-                    elif roles[i].title == "Councilmember":
-                        # conversely, councilmember for city council body only
-                        # (not some committee)
-                        roles[i].title = "Member"
-                    elif roles[i].title == "Council President":
-                        # for any org besides city council, president -> chair
-                        roles[i].title = "Chair"
-                    break
-            else:
-                log.debug(f"{roles[i].title} for is unrecognized. defaulting to Member")
-                roles[i].title = "Member"
-
-            # get all councilmember terms
-            if (
-                roles[i].title == "Councilmember"
-                and roles[i].start_datetime is not None
-                and roles[i].end_datetime is not None
-            ):
-                terms.append(
-                    CouncilMemberTerm(roles[i].start_datetime, roles[i].end_datetime, i)
-                )
-
-        # sort in asc order of start_datetime and end_datetime.
-        terms.sort()
-        # if term i overlaps with term j, end term i before term j
-        for i, term in enumerate(terms[:-1]):
-            if terms[i].end_datetime > terms[i + 1].start_datetime:
-                # reflect adjusted role end date in the actual roles list
-                roles[terms[i].roles_index].end_datetime = terms[
-                    i + 1
-                ].start_datetime - timedelta(days=1)
-
-        return roles

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -265,7 +265,7 @@ def sanitize_roles(
 
     if not known_static_data or not known_static_data.primary_bodies:
         # Primary/full council not defined in static data file
-        primary_body_names = ["city council", "city briefing"]
+        primary_body_names = ["city council", "council briefing"]
     else:
         primary_body_names = [
             body_name.lower() for body_name in known_static_data.primary_bodies.keys()

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -333,8 +333,7 @@ def sanitize_roles(
         # no Councilmember roles dynamically scraped
         return reduced_list(roles)
 
-    # sort in asc order of start_datetime and end_datetime.
-    terms.sort()
+    terms.sort(key=lambda t: (t.start_datetime, t.end_datetime))
     # if term i overlaps with term j, end term i before term j
     for i, term in enumerate(terms[:-1]):
         if terms[i].end_datetime > terms[i + 1].start_datetime:

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -343,12 +343,13 @@ def sanitize_roles(
     class CouncilMemberTerm(NamedTuple):
         start_datetime: datetime
         end_datetime: datetime
-        roles_index: int
+        index_in_roles: int
 
-    scraped_terms: List[CouncilMemberTerm] = []
+    scraped_terms: Dict[str, List[CouncilMemberTerm]] = {}
 
     for i, role in enumerate(roles):
         if not _is_role_period_ok(role):
+            # Nones get removed below
             roles[i] = None
         elif not _is_primary_body(role):
             # Role is not for a primary/full council
@@ -361,9 +362,14 @@ def sanitize_roles(
         else:
             role.title = _get_primary_title(role)
             if _is_councilmember_term(role):
-                scraped_terms.append(
-                    CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
-                )
+                try:
+                    scraped_terms[role.body.name].append(
+                        CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
+                    )
+                except KeyError:
+                    scraped_terms[role.body.name] = [
+                        CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
+                    ]
 
     if have_primary_roles:
         # don't forget to include info from the static data file
@@ -372,14 +378,15 @@ def sanitize_roles(
         # no Councilmember roles dynamically scraped
         return reduced_list(roles)
 
-    scraped_terms.sort(key=lambda t: (t.start_datetime, t.end_datetime))
-    # if term i overlaps with term j, end term i before term j
-    for i, term in enumerate(scraped_terms[:-1]):
-        if scraped_terms[i].end_datetime > scraped_terms[i + 1].start_datetime:
-            # reflect adjusted role end date in the actual roles list
-            roles[scraped_terms[i].roles_index].end_datetime = scraped_terms[
-                i + 1
-            ].start_datetime - timedelta(days=1)
+    for body, terms in scraped_terms.items():
+        terms.sort(key=lambda t: (t.start_datetime, t.end_datetime))
+        # if term i overlaps with term j, end term i before term j
+        for i, term in enumerate(terms):
+            if terms[i].end_datetime > terms[i + 1].start_datetime:
+                # reflect adjusted role end date in the actual roles list
+                roles[terms[i].index_in_roles].end_datetime = terms[
+                    i + 1
+                ].start_datetime - timedelta(days=1)
 
     return reduced_list(roles)
 

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -227,7 +227,11 @@ def sanitize_roles(
     for i, role in enumerate(roles):
         role_title = str_simplified(role.title).lower()
 
-        if str_simplified(role.body.name).lower() in primary_body_names:
+        if (
+            role.body is not None
+            and role.body.name is not None
+            and str_simplified(role.body.name).lower() in primary_body_names
+        ):
             if have_primary_roles:
                 roles[i] = None
             elif re.search("|".join(president_patterns), role_title, re.I) is not None:

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -343,13 +343,12 @@ def sanitize_roles(
     class CouncilMemberTerm(NamedTuple):
         start_datetime: datetime
         end_datetime: datetime
-        index_in_roles: int
+        roles_index: int
 
-    scraped_terms: Dict[str, List[CouncilMemberTerm]] = {}
+    scraped_terms: List[CouncilMemberTerm] = []
 
     for i, role in enumerate(roles):
         if not _is_role_period_ok(role):
-            # Nones get removed below
             roles[i] = None
         elif not _is_primary_body(role):
             # Role is not for a primary/full council
@@ -362,14 +361,9 @@ def sanitize_roles(
         else:
             role.title = _get_primary_title(role)
             if _is_councilmember_term(role):
-                try:
-                    scraped_terms[role.body.name].append(
-                        CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
-                    )
-                except KeyError:
-                    scraped_terms[role.body.name] = [
-                        CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
-                    ]
+                scraped_terms.append(
+                    CouncilMemberTerm(role.start_datetime, role.end_datetime, i)
+                )
 
     if have_primary_roles:
         # don't forget to include info from the static data file
@@ -378,15 +372,14 @@ def sanitize_roles(
         # no Councilmember roles dynamically scraped
         return reduced_list(roles)
 
-    for body, terms in scraped_terms.items():
-        terms.sort(key=lambda t: (t.start_datetime, t.end_datetime))
-        # if term i overlaps with term j, end term i before term j
-        for i, term in enumerate(terms):
-            if terms[i].end_datetime > terms[i + 1].start_datetime:
-                # reflect adjusted role end date in the actual roles list
-                roles[terms[i].index_in_roles].end_datetime = terms[
-                    i + 1
-                ].start_datetime - timedelta(days=1)
+    scraped_terms.sort(key=lambda t: (t.start_datetime, t.end_datetime))
+    # if term i overlaps with term j, end term i before term j
+    for i, term in enumerate(scraped_terms[:-1]):
+        if scraped_terms[i].end_datetime > scraped_terms[i + 1].start_datetime:
+            # reflect adjusted role end date in the actual roles list
+            roles[scraped_terms[i].roles_index].end_datetime = scraped_terms[
+                i + 1
+            ].start_datetime - timedelta(days=1)
 
     return reduced_list(roles)
 

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -1,8 +1,8 @@
-from itertools import filterfalse, groupby
 import json
 import re
 from copy import deepcopy
 from datetime import datetime, timedelta
+from itertools import filterfalse, groupby
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
@@ -17,6 +17,7 @@ from cdp_backend.pipeline.ingestion_models import (
     Seat,
 )
 from cdp_backend.utils.constants_utils import get_all_class_attr_values
+
 from .types import ScraperStaticData
 
 ###############################################################################

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
+from cdp_backend.pipeline.ingestion_models import (
+    Body,
+    Person,
+    Seat,
+)
 
 ###############################################################################
 
@@ -9,3 +14,9 @@ from typing import NamedTuple, Optional
 class ContentURIs(NamedTuple):
     video_uri: Optional[str]
     caption_uri: Optional[str] = None
+
+
+class ScraperStaticData(NamedTuple):
+    seats: Dict[str, Seat] = {}
+    primary_bodies: Dict[str, Body] = {}
+    persons: Dict[str, Person] = {}

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -17,6 +17,6 @@ class ContentURIs(NamedTuple):
 
 
 class ScraperStaticData(NamedTuple):
-    seats: Dict[str, Seat] = {}
-    primary_bodies: Dict[str, Body] = {}
-    persons: Dict[str, Person] = {}
+    seats: Dict[str, Seat] = None
+    primary_bodies: Dict[str, Body] = None
+    persons: Dict[str, Person] = None


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #66 

### Description of Changes

_Include a description of the proposed changes._

`sanitize_roles()` was added to ensure
1. Standardize `Role.title` to one of a preset list. This includes using `Councilmember` and `Council President` only if `Role.body.name` is like `city council`; last word is `council` - this handles councils like `city council` and `county council`.
2. Only one `role` in `Person.seat.roles` with `Role.title = "Councilmember"` in a given period time. This includes adjusting `Role.end_datetime` to remove overlaps.

For example, if `Person.seat.roles` is like

```Python
[
    {
        end_datetime = datetime(2022, 2, 1),
        title = "Councilmember",
    },
    {
        start_datetime = datetime(2022, 1, 31),
        title = "Councilmember",
    },
]
```

after `sanitize_roles()`,

```Python
[
    {
        end_datetime = datetime(2022, 1, 30), # adjusted
        title = "Councilmember",
    },
    {
        start_datetime = datetime(2022, 1, 31),
        title = "Councilmember",
    },
]
```
