### PR TITLE
bugfix/seattle-check-bs4-call-result

### DIFF
--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -136,9 +136,16 @@ class SeattleScraper(LegistarScraper):
         # ...
 
         # entire script tag text that has the video player setup call
-        video_script_text = soup.find(
+        video_script_block = soup.find(
             "script", text=re.compile(r"playerInstance\.setup")
-        ).string
+        )
+        if not video_script_block:
+            log.warning(
+                f"Couldn't find 'playerInstance.setup()' block on {video_page_url}.\n"
+                "seattlechannel.org may have changed their video page html"
+            )
+            return []
+        video_script_text = video_script_block.string
 
         # halt if event date not in video's idstring
         # likely means some change on video web page source / script


### PR DESCRIPTION
### Link to Relevant Issue

[`seattle-staging`](https://github.com/CouncilDataProject/seattle-staging) events processing [failed](https://github.com/CouncilDataProject/seattle-staging/runs/5193689492?check_suite_focus=true) due to `SeattleScraper` unable to find video player setup JavaScript block on a video page.

```Python
  File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/cdp_scrapers/instances/seattle.py", line 134, in parse_content_uris
    video_script_text = soup.find(
AttributeError: 'NoneType' object has no attribute 'string'
```

### Description of Changes

_Include a description of the proposed changes._

Added checking for `None` in `SeattleScraper.parse_content_uris()`.

The weird thing is that I am not able to reproduce the error from the referenced events gathering.

```Python
from cdp_scrapers.instances.seattle import SeattleScraper
s = SeattleScraper()
from datetime import datetime
events = s.get_events(
    # same period from the referenced run
    begin=datetime.fromisoformat("2022-02-13T01:47:10.129818"),
    end=datetime.fromisoformat("2022-02-15T01:47:10.129845")
)
# no exceptions
```

Using

```Shell
$ conda list cdp
# packages in environment at /home/deux/anaconda3/envs/cdp:
#
# Name                    Version                   Build  Channel
cdp-backend               3.0.4                    pypi_0    pypi
cdp-scrapers              0.3.4                    pypi_0    pypi
```