### PR TITLE
bugfix/trim-query-parameters-from-video-urls

### DIFF
--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -8,22 +8,13 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup, Tag
-from cdp_backend.database.constants import (
-    MatterStatusDecision,
-    VoteDecision,
-    EventMinutesItemDecision,
-)
-from cdp_backend.pipeline.ingestion_models import (
-    Body,
-    EventIngestionModel,
-    EventMinutesItem,
-    Matter,
-    MinutesItem,
-    Person,
-    Session,
-    SupportingFile,
-    Vote,
-)
+from cdp_backend.database.constants import (EventMinutesItemDecision,
+                                            MatterStatusDecision, VoteDecision)
+from cdp_backend.pipeline.ingestion_models import (Body, EventIngestionModel,
+                                                   EventMinutesItem, Matter,
+                                                   MinutesItem, Person,
+                                                   Session, SupportingFile,
+                                                   Vote)
 
 from ..scraper_utils import IngestionModelScraper, reduced_list, str_simplified
 
@@ -554,7 +545,7 @@ class PortlandScraper(IngestionModelScraper):
                                 )
                             ),
                             session_index=session_index,
-                            video_uri=video_iframe["src"],
+                            video_uri=video_iframe["src"].split("?")[0],
                         )
                     )
                 )

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -8,13 +8,22 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup, Tag
-from cdp_backend.database.constants import (EventMinutesItemDecision,
-                                            MatterStatusDecision, VoteDecision)
-from cdp_backend.pipeline.ingestion_models import (Body, EventIngestionModel,
-                                                   EventMinutesItem, Matter,
-                                                   MinutesItem, Person,
-                                                   Session, SupportingFile,
-                                                   Vote)
+from cdp_backend.database.constants import (
+    EventMinutesItemDecision,
+    MatterStatusDecision,
+    VoteDecision,
+)
+from cdp_backend.pipeline.ingestion_models import (
+    Body,
+    EventIngestionModel,
+    EventMinutesItem,
+    Matter,
+    MinutesItem,
+    Person,
+    Session,
+    SupportingFile,
+    Vote,
+)
 
 from ..scraper_utils import IngestionModelScraper, reduced_list, str_simplified
 

--- a/cdp_scrapers/tests/scraper_tests.py
+++ b/cdp_scrapers/tests/scraper_tests.py
@@ -158,7 +158,7 @@ def test_king_county_scraper(
             0,
             2,
             5,
-            "https://www.youtube.com/embed/aXKE2u24WKg?autoplay=0&start=0&rel=0",
+            "https://www.youtube.com/embed/aXKE2u24WKg",
             "https://efiles.portlandoregon.gov/record/14778119/File/Document",
         ),
         (
@@ -170,7 +170,7 @@ def test_king_county_scraper(
             0,
             5,
             5,
-            "https://www.youtube.com/embed/TBrJbm08i0g?autoplay=0&start=0&rel=0",
+            "https://www.youtube.com/embed/TBrJbm08i0g",
             "https://efiles.portlandoregon.gov/record/14811424/File/Document",
         ),
         (
@@ -182,7 +182,7 @@ def test_king_county_scraper(
             0,
             6,
             5,
-            "https://www.youtube.com/embed/3mYGdqck_bw?autoplay=0&start=0&rel=0",
+            "https://www.youtube.com/embed/3mYGdqck_bw",
             "https://efiles.portlandoregon.gov/record/14750779/File/Document",
         ),
     ],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to relevant issue

This pull request resolves #77 

### Description of Changes

Make the Portland scraper trim YouTube parameters from the YouTube video URI's.
