### PR TITLE
admin/portland-new-person

### DIFF
--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -273,7 +273,7 @@
                 "external_source_id": null,
                 "roles": [
                     {
-                        "title":  "Member",
+                        "title":  "Councilmember",
                         "start_datetime": 1420099200,
                         "end_datetime": 1735632000,
                         "body": {"name": "City Council"}

--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -256,6 +256,31 @@
                 ]
             },
             "external_source_id": null
+        },
+        "Mary Hull Caballero": {
+            "name": "Mary Hull Caballero",
+            "is_active": true,
+            "router_string": null,
+            "email": "auditorhullcaballero@portlandoregon.gov",
+            "phone": "503-823-4078",
+            "website": "https://www.portland.gov/auditor/hull-caballero",
+            "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_640w/public/2021/mary-hull-caballero_headshot.jpg",
+            "seat": {
+                "name": "Auditor",
+                "electoral_area": "Citywide",
+                "electoral_type": null,
+                "image_uri": "https://www.portland.gov/sites/default/files/styles/featured_2_1_600w/public/2020-08/environmental-services-program.jpg",
+                "external_source_id": null,
+                "roles": [
+                    {
+                        "title":  "Member",
+                        "start_datetime": 1420099200,
+                        "end_datetime": 1735632000,
+                        "body": {"name": "City Council"}
+                    }
+                ]
+            },
+            "external_source_id": null
         }
     }
 }

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -220,7 +220,7 @@ class PortlandScraper(IngestionModelScraper):
 
         Returns
         -------
-        person: Optional[Person]:
+        person: Person
             Matching Person from portland-static.json
 
         Raises

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -223,6 +223,11 @@ class PortlandScraper(IngestionModelScraper):
         person: Optional[Person]:
             Matching Person from portland-static.json
 
+        Raises
+        ------
+        KeyError
+            If name does not exist in portland-static.json
+
         References
         ----------
         portland-static.json

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -209,7 +209,7 @@ class PortlandScraper(IngestionModelScraper):
     def __init__(self):
         super().__init__(timezone="America/Los_Angeles")
 
-    def get_person(self, name: str) -> Optional[Person]:
+    def get_person(self, name: str) -> Person:
         """
         Return matching Person from portland-static.json
 
@@ -221,20 +221,16 @@ class PortlandScraper(IngestionModelScraper):
         Returns
         -------
         person: Optional[Person]:
-            Person if exists in portland-static.json
+            Matching Person from portland-static.json
 
         References
         ----------
         portland-static.json
         """
-        global known_persons
-        try:
-            return known_persons[name]
-        except KeyError:
-            pass
+        if name not in known_persons:
+            raise KeyError(f"{name} is unknown. Please update portland-static.json")
 
-        log.warning(f"{name} is unknown. Please update portland-static.json")
-        return None
+        return known_persons[name]
 
     def get_matter(self, minute_section: Tag) -> Optional[Matter]:
         """


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves https://github.com/CouncilDataProject/portland/runs/5488795374?check_suite_focus=true#step:9:16

### Description of Changes

_Include a description of the proposed changes._

Added Mary Hull Caballero to `portland-static.json`.

`PortlandScraper` relies entirely on the file for `Persons`; information for `Persons` are not scraped at runtime. Because of this, `get_person()` now raises a `KeyError` when a new person is encountered. The intent/hope is that this missing information is more obviously alerted to the maintainer(s).