### PR TITLE
bugfix/remove-canceled-events-from-portland-scraper

### DIFF
--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -8,22 +8,13 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup, Tag
-from cdp_backend.database.constants import (
-    EventMinutesItemDecision,
-    MatterStatusDecision,
-    VoteDecision,
-)
-from cdp_backend.pipeline.ingestion_models import (
-    Body,
-    EventIngestionModel,
-    EventMinutesItem,
-    Matter,
-    MinutesItem,
-    Person,
-    Session,
-    SupportingFile,
-    Vote,
-)
+from cdp_backend.database.constants import (EventMinutesItemDecision,
+                                            MatterStatusDecision, VoteDecision)
+from cdp_backend.pipeline.ingestion_models import (Body, EventIngestionModel,
+                                                   EventMinutesItem, Matter,
+                                                   MinutesItem, Person,
+                                                   Session, SupportingFile,
+                                                   Vote)
 
 from ..scraper_utils import IngestionModelScraper, reduced_list, str_simplified
 
@@ -655,7 +646,10 @@ class PortlandScraper(IngestionModelScraper):
         if agenda_uri_element is not None:
             return make_efile_url(agenda_uri_element["href"])
         parent_agenda_uri_element = event_page.find("div", {"class": "inline-flex"})
-        agenda_uri_element = parent_agenda_uri_element.find("a")
+        if parent_agenda_uri_element is not None:
+            agenda_uri_element = parent_agenda_uri_element.find("a")
+        else:
+            return None
         if agenda_uri_element is not None:
             return f"https://www.portland.gov{agenda_uri_element['href']}"
         return None

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -8,13 +8,22 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup, Tag
-from cdp_backend.database.constants import (EventMinutesItemDecision,
-                                            MatterStatusDecision, VoteDecision)
-from cdp_backend.pipeline.ingestion_models import (Body, EventIngestionModel,
-                                                   EventMinutesItem, Matter,
-                                                   MinutesItem, Person,
-                                                   Session, SupportingFile,
-                                                   Vote)
+from cdp_backend.database.constants import (
+    EventMinutesItemDecision,
+    MatterStatusDecision,
+    VoteDecision,
+)
+from cdp_backend.pipeline.ingestion_models import (
+    Body,
+    EventIngestionModel,
+    EventMinutesItem,
+    Matter,
+    MinutesItem,
+    Person,
+    Session,
+    SupportingFile,
+    Vote,
+)
 
 from ..scraper_utils import IngestionModelScraper, reduced_list, str_simplified
 

--- a/cdp_scrapers/tests/scraper_tests.py
+++ b/cdp_scrapers/tests/scraper_tests.py
@@ -150,6 +150,18 @@ def test_king_county_scraper(
     "number_of_votes, expected_video_uri_in_first_session, expected_agenda_uri",
     [
         (
+            datetime(2021, 8, 19),
+            datetime(2021, 8, 31),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "",
+            "",
+        ),
+        (
             datetime(2021, 8, 18),
             datetime(2021, 8, 19),
             1,
@@ -214,17 +226,21 @@ def test_portland_scraper(
     portland = PortlandScraper()
     portland_events = portland.get_events(start_date_time, end_date_time)
     assert len(portland_events) == number_of_events
-    assert len(portland_events[0].event_minutes_items) == number_of_event_minute_items
-    assert len(portland_events[0].sessions) == number_of_sessions
-    assert (
-        portland_events[0].sessions[0].video_uri == expected_video_uri_in_first_session
-    )
-    assert (
-        len(
-            portland_events[event_with_votes]
-            .event_minutes_items[event_minute_item_with_votes]
-            .votes
+    if number_of_events > 0:
+        assert (
+            len(portland_events[0].event_minutes_items) == number_of_event_minute_items
         )
-        == number_of_votes
-    )
-    assert portland_events[0].agenda_uri == expected_agenda_uri
+        assert len(portland_events[0].sessions) == number_of_sessions
+        assert (
+            portland_events[0].sessions[0].video_uri
+            == expected_video_uri_in_first_session
+        )
+        assert (
+            len(
+                portland_events[event_with_votes]
+                .event_minutes_items[event_minute_item_with_votes]
+                .votes
+            )
+            == number_of_votes
+        )
+        assert portland_events[0].agenda_uri == expected_agenda_uri


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #86 

### Description of Changes

This pull request would fix a bug in the Portland scraper that produces exceptions when the event is empty or canceled.
