### PR TITLE
feature/get-updated-legistar-matter

### DIFF
--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1564,7 +1564,7 @@ class LegistarScraper(IngestionModelScraper):
 
         return events
 
-    def get_model(
+    def get_updated_model(
         self, model: IngestionModel, **kwargs: Any
     ) -> Optional[IngestionModel]:
         """

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1155,7 +1155,7 @@ class LegistarScraper(IngestionModelScraper):
         matter.sponsors = (
             [self.inject_known_person(sponsor) for sponsor in matter.sponsors]
             if matter.sponsors is not None
-            else []
+            else None
         )
         return matter
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1152,10 +1152,11 @@ class LegistarScraper(IngestionModelScraper):
         if matter is None:
             return None
 
-        if matter.sponsors is not None:
-            matter.sponsors = [
-                self.inject_known_person(sponsor) for sponsor in matter.sponsors
-            ]
+        matter.sponsors = (
+            [self.inject_known_person(sponsor) for sponsor in matter.sponsors]
+            if matter.sponsors is not None
+            else []
+        )
         return matter
 
     def get_minutes_item(self, legistar_ev_item: Dict) -> Optional[MinutesItem]:

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1148,7 +1148,16 @@ class LegistarScraper(IngestionModelScraper):
 
         if matter_id is None:
             return None
-        return self.get_matter(get_legistar_matter(self.client_name, matter_id))
+        matter = self.get_matter(get_legistar_matter(self.client_name, matter_id))
+        if matter is None:
+            return None
+
+        if matter.sponsors is not None:
+            matter.sponsors = [
+                self.inject_known_person(sponsor)
+                for sponsor in matter.sponsors
+            ]
+        return matter
 
     def get_minutes_item(self, legistar_ev_item: Dict) -> Optional[MinutesItem]:
         """

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1154,8 +1154,7 @@ class LegistarScraper(IngestionModelScraper):
 
         if matter.sponsors is not None:
             matter.sponsors = [
-                self.inject_known_person(sponsor)
-                for sponsor in matter.sponsors
+                self.inject_known_person(sponsor) for sponsor in matter.sponsors
             ]
         return matter
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -267,11 +267,18 @@ def get_legistar_matter(
     matter: Dict[str, Any]
         legistar API Matter
     """
-    matter: Dict[str, Any] = requests.get(
+    resp = requests.get(
         (LEGISTAR_MATTER_BASE + "/{matter_id}").format(
             client=client, matter_id=matter_id
         )
-    ).json()
+    )
+    if resp.status_code != 200:
+        log.debug(
+            f"{resp.status_code} ({resp.reason}) from querying for "
+            f"Legistar Matter with MatterId = {matter_id}"
+        )
+        return None
+    matter: Dict[str, Any] = resp.json()
 
     # Person JSON for this matter's sponsors
     matter[LEGISTAR_MATTER_SPONSORS] = reduced_list(

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1134,7 +1134,7 @@ class LegistarScraper(IngestionModelScraper):
             ]
             try:
                 matter_matches.sort(
-                    # just in case we get multiple Matters that same name,
+                    # just in case we get multiple Matters with same name,
                     # use the latest one
                     key=lambda legistar_matter: datetime.fromisoformat(
                         legistar_matter["MatterLastModifiedUtc"]


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is a part of #59 .

### Description of Changes

`LegistarScraper.get_updated_model(matter)` -> `LegistarScraper.get_updated_model(matter)` where Legistar API is queried for the given `matter`.

```Python
from cdp_backend.pipeline.ingestion_models import Matter
from cdp_scrapers.instances.seattle import SeattleScraper

old_matter = Matter(name="CB 120305", matter_type=None, title=None)
s = SeattleScraper()
s.get_updated_model(old_matter)
# Matter(name='CB 120305', matter_type='Council Bill (CB)', title='CB 120305', result_status='In Progress', sponsors=[Person(name='Dan Strauss', is_active=True, router_string=None, email='Dan.Strauss@seattle.gov', phone='206-684-8806', website='http://www.seattle.gov/council/strauss', picture_uri=None, seat=None, external_source_id='664')], external_source_id='12846')

s.get_updated_model(Matter(name=None, matter_type=None, title=None, external_source_id=1))
# None
```

Eventually, will provide API similar to `get_{municipality}_events()`, e.g.

```Python
from cdp_scrapers.instances import get_seattle_updated_model
get_seattle_updated_model(old_matter)