### PR TITLE
feature/scrape-granicus-videos

### DIFF
--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -4,8 +4,7 @@
 import logging
 import re
 import json
-from typing import Dict, List
-from urllib.error import HTTPError, URLError
+from typing import Dict
 from urllib.request import urlopen
 from pathlib import Path
 
@@ -14,11 +13,9 @@ from bs4 import BeautifulSoup
 from cdp_backend.pipeline.ingestion_models import Person, Seat
 from cdp_backend.database.constants import RoleTitle
 from ..legistar_utils import (
-    LEGISTAR_EV_SITE_URL,
     LegistarScraper,
 )
 from ..scraper_utils import str_simplified, parse_static_file
-from ..types import ContentURIs
 
 ###############################################################################
 
@@ -71,26 +68,6 @@ class KingCountyScraper(LegistarScraper):
                 "Policy Chair": RoleTitle.CHAIR,
             },
         )
-
-    def get_content_uris(self, legistar_ev: Dict) -> None:
-        """
-        Simply return None. get_legistar_content_uris() will have retrieved video.
-        If here, means no video.
-
-        Parameters
-        ----------
-        legistar_ev: Dict
-            Data for one Legistar Event.
-
-        Returns
-        -------
-        None
-
-        See Also
-        --------
-        cdp_scrapers.legistar_utils.get_legistar_content_uris
-        """
-        return None
 
     @staticmethod
     def get_static_person_info() -> Dict[str, Person]:

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1412,8 +1412,11 @@ class LegistarScraper(IngestionModelScraper):
         """
         # see if our base legistar/granicus video parsing routine will work
         result, uris = get_legistar_content_uris(self.client_name, legistar_ev)
-        if result is ContetUriScrapeResult.Status.Ok:
-            return uris
+        if result in [
+            ContetUriScrapeResult.Status.Ok,
+            ContetUriScrapeResult.Status.ContentNotProvidedError,
+        ]:
+            return uris or []
 
         raise NotImplementedError(
             f"Please provide get_content_uris() for {self.client_name}"

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1391,11 +1391,14 @@ class LegistarScraper(IngestionModelScraper):
         --------
         cdp_scrapers.legistar_utils.get_legistar_events_for_timespan
         """
-        log.critical(
-            "get_content_uris() is required because "
-            f"Legistar Event.EventVideoPath is not used by {self.client_name}"
+        # see if our base legistar/granicus video parsing routine will work
+        list_uri = get_legistar_content_uris(self.client_name, legistar_ev)
+        if list_uri is not None:
+            return list_uri
+
+        raise NotImplementedError(
+            f"Please provide get_content_uris() for {self.client_name}"
         )
-        raise NotImplementedError
 
     def inject_known_person(self, person: Person) -> Person:
         """
@@ -1547,12 +1550,9 @@ class LegistarScraper(IngestionModelScraper):
                     legistar_ev[LEGISTAR_SESSION_TIME],
                 )
             )
-            # see if our base legistar/granicus video parsing routine will work
-            list_uri = get_legistar_content_uris(self.client_name, legistar_ev)
-            if list_uri is None:
-                list_uri = self.get_content_uris(legistar_ev)
-            if list_uri is None:
-                list_uri = [ContentURIs(video_uri=None, caption_uri=None)]
+            list_uri = self.get_content_uris(legistar_ev) or [
+                ContentURIs(video_uri=None, caption_uri=None)
+            ]
 
             ingestion_models.append(
                 self.get_none_if_empty(

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -502,7 +502,7 @@ def get_legistar_content_uris(
                 uris = parser(soup)
                 if uris is not None:
                     # remember so we just call this from here on
-                    my_video_page_parser = _parse_format_1
+                    my_video_page_parser = parser
                     break
             else:
                 uris = None

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -381,7 +381,7 @@ def get_legistar_events_for_timespan(
     return response
 
 
-class ContetUriScrapeResult(NamedTuple):
+class ContentUriScrapeResult(NamedTuple):
     class Status(enum.IntEnum):
         # Web page(s) are in unrecognized structure
         UnrecognizedPatternError = -1
@@ -396,7 +396,7 @@ class ContetUriScrapeResult(NamedTuple):
     uris: Optional[List[ContentURIs]] = None
 
 
-def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrapeResult:
+def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContentUriScrapeResult:
     """
     Return URLs for videos and captions from a Legistar/Granicus-hosted video web page
 
@@ -409,9 +409,9 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
 
     Returns
     -------
-    ContetUriScrapeResult
-        status: ContetUriScrapeResult.Status
-            Statu code describing the scraping process. Use uris only if status is Ok
+    ContentUriScrapeResult
+        status: ContentUriScrapeResult.Status
+            StatuS code describing the scraping process. Use uris only if status is Ok
         uris: Optional[List[ContentURIs]]
             URIs for video and optional caption
 
@@ -426,7 +426,7 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
     # prefer video file path in legistar Event.EventVideoPath
     if legistar_ev[LEGISTAR_SESSION_VIDEO_URI]:
         return (
-            ContetUriScrapeResult.Status.Ok,
+            ContentUriScrapeResult.Status.Ok,
             [
                 ContentURIs(
                     video_uri=str_simplified(legistar_ev[LEGISTAR_SESSION_VIDEO_URI]),
@@ -435,7 +435,7 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
             ],
         )
     if not legistar_ev[LEGISTAR_EV_SITE_URL]:
-        return (ContetUriScrapeResult.Status.UnrecognizedPatternError, None)
+        return (ContentUriScrapeResult.Status.UnrecognizedPatternError, None)
 
     try:
         # a td tag with a certain id pattern.
@@ -447,7 +447,7 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
 
     except (URLError, HTTPError) as e:
         log.debug(f"{legistar_ev[LEGISTAR_EV_SITE_URL]}: {str(e)}")
-        return (ContetUriScrapeResult.Status.ResourceAccessError, None)
+        return (ContentUriScrapeResult.Status.ResourceAccessError, None)
 
     # this gets us the url for the web PAGE containing the video
     # video link is provided in the window.open()command inside onclick event
@@ -464,10 +464,10 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
         class_="videolink",
     )
     if extract_url is None:
-        return (ContetUriScrapeResult.Status.UnrecognizedPatternError, None)
+        return (ContentUriScrapeResult.Status.UnrecognizedPatternError, None)
     # the <a> tag will not have this attribute if there is no video
     if "onclick" not in extract_url.attrs:
-        return (ContetUriScrapeResult.Status.ContentNotProvidedError, None)
+        return (ContentUriScrapeResult.Status.ContentNotProvidedError, None)
 
     # NOTE: after this point, failing to scrape video url should raise an exception.
     # we need to be alerted that we probabaly have a new web page structure.
@@ -557,7 +557,7 @@ def get_legistar_content_uris(client: str, legistar_ev: Dict) -> ContetUriScrape
             "get_legistar_content_uris() needs attention. "
             f"Unrecognized video web page HTML structure: {video_page_url}"
         )
-    return (ContetUriScrapeResult.Status.Ok, uris)
+    return (ContentUriScrapeResult.Status.Ok, uris)
 
 
 class LegistarScraper(IngestionModelScraper):
@@ -1413,8 +1413,8 @@ class LegistarScraper(IngestionModelScraper):
         # see if our base legistar/granicus video parsing routine will work
         result, uris = get_legistar_content_uris(self.client_name, legistar_ev)
         if result in [
-            ContetUriScrapeResult.Status.Ok,
-            ContetUriScrapeResult.Status.ContentNotProvidedError,
+            ContentUriScrapeResult.Status.Ok,
+            ContentUriScrapeResult.Status.ContentNotProvidedError,
         ]:
             return uris or []
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -376,9 +376,7 @@ def get_legistar_events_for_timespan(
     return response
 
 
-def get_legistar_content_uris(
-    legistar_ev: Dict[str, Any]
-) -> Optional[List[ContentURIs]]:
+def get_legistar_content_uris(legistar_ev: Dict) -> Optional[List[ContentURIs]]:
     """
     Return URLs for videos and captions from a Legistar/Granicus-hosted video web page
 

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1494,8 +1494,10 @@ class LegistarScraper(IngestionModelScraper):
             list_uri = (
                 get_legistar_content_uris(legistar_ev)
                 or self.get_content_uris(legistar_ev)
-                or [ContentURIs(video_uri=None, caption_uri=None)]
             )
+            if list_uri is None:
+                # for easier iteration below; will collapse to None
+                list_uri = [ContentURIs(video_uri=None, caption_uri=None)]
 
             ingestion_models.append(
                 self.get_none_if_empty(


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #89 

### Description of Changes

`legistar_utils.get_legistar_content_uris()`
Try to parse and return `Session.video_uri` if video web page is in expected Legistar/Granius structure.

`LegistarScraper.get_content_uris()`
1. `get_legistar_content_uris()` 
3. `raise NotImplementedError`

As before, instances override `get_content_uris()` to provide own video/caption scraper, e.g. `SeattleScraper.get_content_uris()`.

The hope is that for municipalities that use Legistar/Granicus, instances do not have to implement their own `get_content_uris()`.

### Quickstart

```Python
from cdp_scrapers.legistar_utils import LegistarScraper
from datetime import datetime
scraper = LegistarScraper("denver", "America/Denver")
events = scraper.get_events(datetime(2022, 4, 20), datetime(2022, 4, 21))
print(events[0].sessions[0].video_uri)
# http://archive-media.granicus.com:443/OnDemand/denver/denver_8abd62f8-dcc2-45a9-9ff2-4a59c3aa92e0.mp4
```
