### PR TITLE
replacing text cleanup with standard library

### DIFF
--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -10,13 +10,8 @@ from typing import Any, Dict, List, NamedTuple, Optional, Set
 import cleantext
 import pytz
 from cdp_backend.database.constants import RoleTitle
-from cdp_backend.pipeline.ingestion_models import (
-    Body,
-    IngestionModel,
-    Person,
-    Role,
-    Seat,
-)
+from cdp_backend.pipeline.ingestion_models import (Body, IngestionModel,
+                                                   Person, Role, Seat)
 from cdp_backend.utils.constants_utils import get_all_class_attr_values
 
 from .types import ScraperStaticData
@@ -53,35 +48,6 @@ def reduced_list(input_list: List[Any], collapse: bool = True) -> Optional[List]
 
 
 def str_simplified(input_str: str) -> str:
-    """
-    Remove leading and trailing whitespaces, simplify multiple whitespaces, unify
-    newline characters.
-
-    Parameters
-    ----------
-    input_str: str
-
-    Returns
-    -------
-    cleaned: str
-        input_str stripped if it is a string
-    """
-    if not isinstance(input_str, str):
-        return input_str
-
-    input_str = input_str.strip()
-    # unify newline to \n
-    input_str = re.sub(r"[\r\n\f]+", r"\n", input_str)
-    # multiple spaces and tabs to 1 space
-    input_str = re.sub(r"[ \t\v]+", " ", input_str)
-
-    # Replace utf-8 char encodings with single utf-8 chars themselves
-    input_str = input_str.encode("utf-8").decode("utf-8")
-
-    return input_str
-
-
-def str_simplified_new(input_str: str) -> str:
     """
     Remove leading and trailing whitespaces, simplify multiple whitespaces, unify
     newline characters.

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -7,15 +7,11 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Set
 
+import cleantext
 import pytz
 from cdp_backend.database.constants import RoleTitle
-from cdp_backend.pipeline.ingestion_models import (
-    Body,
-    IngestionModel,
-    Person,
-    Role,
-    Seat,
-)
+from cdp_backend.pipeline.ingestion_models import (Body, IngestionModel,
+                                                   Person, Role, Seat)
 from cdp_backend.utils.constants_utils import get_all_class_attr_values
 
 from .types import ScraperStaticData
@@ -73,6 +69,33 @@ def str_simplified(input_str: str) -> str:
     input_str = re.sub(r"[\r\n\f]+", r"\n", input_str)
     # multiple spaces and tabs to 1 space
     input_str = re.sub(r"[ \t\v]+", " ", input_str)
+
+    # Replace utf-8 char encodings with single utf-8 chars themselves
+    input_str = input_str.encode("utf-8").decode("utf-8")
+
+    return input_str
+
+
+def str_simplified_new(input_str: str) -> str:
+    """
+    Remove leading and trailing whitespaces, simplify multiple whitespaces, unify
+    newline characters.
+
+    Parameters
+    ----------
+    input_str: str
+
+    Returns
+    -------
+    cleaned: str
+        input_str stripped if it is a string
+    """
+    if not isinstance(input_str, str):
+        return input_str
+
+    input_str = cleantext.clean(
+        input_str, fix_unicode=True, lower=False, to_ascii=False
+    )
 
     # Replace utf-8 char encodings with single utf-8 chars themselves
     input_str = input_str.encode("utf-8").decode("utf-8")

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -10,8 +10,13 @@ from typing import Any, Dict, List, NamedTuple, Optional, Set
 import cleantext
 import pytz
 from cdp_backend.database.constants import RoleTitle
-from cdp_backend.pipeline.ingestion_models import (Body, IngestionModel,
-                                                   Person, Role, Seat)
+from cdp_backend.pipeline.ingestion_models import (
+    Body,
+    IngestionModel,
+    Person,
+    Role,
+    Seat,
+)
 from cdp_backend.utils.constants_utils import get_all_class_attr_values
 
 from .types import ScraperStaticData

--- a/cdp_scrapers/tests/scraper_util_tests.py
+++ b/cdp_scrapers/tests/scraper_util_tests.py
@@ -1,4 +1,3 @@
-import cleantext
 import pytest
 
 from cdp_scrapers.scraper_utils import str_simplified, str_simplified_new

--- a/cdp_scrapers/tests/scraper_util_tests.py
+++ b/cdp_scrapers/tests/scraper_util_tests.py
@@ -1,0 +1,25 @@
+import cleantext
+import pytest
+
+from cdp_scrapers.scraper_utils import str_simplified, str_simplified_new
+
+
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    [
+        (
+            "   test   ",
+            "test",
+        ),
+        ("    test", "test"),
+        ("test     ", "test"),
+        ("test\r\n\ftest", "test\ntest"),
+        ("test \t\vtest", "test test"),
+        ("M. Lorena Gonz\u00e1lez", "M. Lorena González"),
+        (5, 5),
+    ],
+)
+def test_str_simplifed(input_string: str, expected_output: str):
+    # Validate that both methods work the same
+    assert str_simplified(input_string) == expected_output
+    assert str_simplified_new(input_string) == expected_output

--- a/cdp_scrapers/tests/scraper_util_tests.py
+++ b/cdp_scrapers/tests/scraper_util_tests.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cdp_scrapers.scraper_utils import str_simplified, str_simplified_new
+from cdp_scrapers.scraper_utils import str_simplified
 
 
 @pytest.mark.parametrize(
@@ -21,4 +21,3 @@ from cdp_scrapers.scraper_utils import str_simplified, str_simplified_new
 def test_str_simplifed(input_string: str, expected_output: str):
     # Validate that both methods work the same
     assert str_simplified(input_string) == expected_output
-    assert str_simplified_new(input_string) == expected_output

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ requirements = [
     "requests~=2.25",
     "beautifulsoup4>=4.9",
     "pytz>=2021.1",
+    "clean-text~=0.6.0"
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
     "defusedxml~=0.7.1",
     "pytz~=2021.1",
     "requests~=2.25",
-    "clean-text~=0.6.0"
+    "clean-text~=0.6.0",
 ]
 
 extra_requirements = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #88 

### Description of Changes

Replace the `str_simplified` function with `clean-text`.
