### PR TITLE
feature/prime-gov-event-item

### DIFF
--- a/cdp_scrapers/legistar_content_parsers.py
+++ b/cdp_scrapers/legistar_content_parsers.py
@@ -118,9 +118,14 @@ def _parse_format_3(client: str, soup: BeautifulSoup) -> Optional[List[ContentUR
     video_url = soup.find("video")
     if video_url is None:
         return None
+
+    video_uri = str_simplified(video_url.source['src'])
+    if not video_uri.startswith("http"):
+        video_uri = f"https:{video_uri}"
+
     return [
         ContentURIs(
-            video_uri=f"https:{str_simplified(video_url.source['src'])}",
+            video_uri=video_uri,
             caption_uri=(
                 (
                     f"http://{client}.granicus.com/"

--- a/cdp_scrapers/legistar_content_parsers.py
+++ b/cdp_scrapers/legistar_content_parsers.py
@@ -119,7 +119,7 @@ def _parse_format_3(client: str, soup: BeautifulSoup) -> Optional[List[ContentUR
     if video_url is None:
         return None
 
-    video_uri = str_simplified(video_url.source['src'])
+    video_uri = str_simplified(video_url.source["src"])
     if not video_uri.startswith("http"):
         video_uri = f"https:{video_uri}"
 

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -37,11 +37,6 @@ Meeting = Dict[str, Any]
 Agenda = BeautifulSoup
 
 
-class MinutesItemInfo(NamedTuple):
-    name: str
-    desc: str
-
-
 def primegov_strftime(dt: datetime) -> str:
     """
     strftime() in format expected for search by primegov api
@@ -143,7 +138,7 @@ def get_minutes_tables(agenda: Agenda) -> Iterator[Tag]:
     return map(lambda d: d.find("table"), divs)
 
 
-def get_minutes_item(minutes_table: Tag) -> MinutesItemInfo:
+def get_minutes_item(minutes_table: Tag) -> MinutesItem:
     """
     Extract minutes item name and description.
 
@@ -178,7 +173,7 @@ def get_minutes_item(minutes_table: Tag) -> MinutesItemInfo:
             f"Minutes item <table> is no longer recognized: {minutes_table}"
         )
 
-    return MinutesItemInfo(str_simplified(name), str_simplified(desc))
+    return MinutesItem(name=str_simplified(name), description=str_simplified(desc))
 
 
 class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
@@ -276,10 +271,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
         --------
         get_minutes_item()
         """
-        minutes_info = get_minutes_item(minutes_table)
-        return self.get_none_if_empty(
-            MinutesItem(name=minutes_info.name, description=minutes_info.desc)
-        )
+        return self.get_none_if_empty(get_minutes_item(minutes_table))
 
     def get_event(self, meeting: Meeting) -> Optional[EventIngestionModel]:
         """

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -546,6 +546,26 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
         return self.get_none_if_empty(matter)
 
     def get_event_minutes_item(self, minutes_table: Tag) -> Optional[EventMinutesItem]:
+        """
+        Extract event minutes item info from a minutes item <table> on agenda web page
+
+        Parameters
+        ----------
+        minutes_table: Tag
+            <table> tag on agenda web page for a minutes item.
+
+        Returns
+        -------
+        EventMinutesItem
+            Container object with matter, minutes item
+
+        See Also
+        --------
+        get_matter()
+        get_minutes_item()
+        get_support_files()
+        """
+
         def _get_index(minutes_table: Tag) -> Optional[int]:
             # (number)
             index_pattern: Pattern = re.compile(r"\s*\(\s*(\d+)\s*\)\s*")

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -409,13 +409,14 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
         self.matter_adopted_pattern = matter_adopted_pattern
         self.matter_in_progress_pattern = matter_in_progress_pattern
         self.matter_rejected_patten = matter_rejected_pattern
+
         # {"pattern_for_adopted": ADOPTED, ...}
         self.matter_status_pattern_map: Dict[str, MatterStatusDecision] = dict(
             zip(
                 [
                     self.matter_adopted_pattern,
                     self.matter_in_progress_pattern,
-                    self.matter_status_pattern_map,
+                    self.matter_rejected_patten,
                 ],
                 [
                     MatterStatusDecision.ADOPTED,

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import re
 from datetime import datetime
 from logging import getLogger

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -179,6 +179,25 @@ def get_minutes_item(minutes_table: Tag) -> MinutesItem:
     return MinutesItem(name=str_simplified(name), description=str_simplified(desc))
 
 
+def get_support_files_div(minutes_table: Tag) -> Tag:
+    """
+    Find the <div> containing a minutes item's support document URLs
+
+    Parameters
+    ----------
+    minutes_table: Tag
+        <table> for a minutes item on agenda web page
+
+    Returns
+    -------
+    Tag
+        <div> with support documents for the minutes item
+    """
+    # go up from the <table> for this minutes item
+    # then find the next <div> that contains the associated support files.
+    return minutes_table.parent.find_next_sibling("div", class_="item_contents")
+
+
 def get_support_files(minutes_table: Tag) -> Iterator[SupportingFile]:
     """
     Extract the minutes item's support file URLs
@@ -214,6 +233,7 @@ def get_support_files(minutes_table: Tag) -> Iterator[SupportingFile]:
 
         # they sometimes include file suffix in the document title
         # e.g. Budget Recommendation dated 5-18-22.pdf
+        # get rid of the suffix .pdf from the descriptive name for the file
         name = re.sub(r"\.\S{2,4}\s*$", "", url_tag.text)
 
         url: str = url_tag["href"]
@@ -230,9 +250,7 @@ def get_support_files(minutes_table: Tag) -> Iterator[SupportingFile]:
             external_source_id=id, name=str_simplified(name), uri=str_simplified(url)
         )
 
-    # go up from the <table> for this minutes item
-    # then find the next <div> that contains the associated support files.
-    contents_div = minutes_table.parent.find_next_sibling("div", class_="item_contents")
+    contents_div = get_support_files_div(minutes_table)
     file_divs = contents_div.find_all("div", class_="attachment-holder")
     return map(extract_file, file_divs)
 

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -1,7 +1,7 @@
+import re
 from datetime import datetime
 from logging import getLogger
 from pathlib import Path
-import re
 from typing import Any, Dict, Iterator, List, Optional, Pattern, Set, Tuple
 
 import requests

--- a/cdp_scrapers/tests/legistar_content_parser_test.py
+++ b/cdp_scrapers/tests/legistar_content_parser_test.py
@@ -12,7 +12,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             + "D64F10C7-C196-4013-ABF6-0DA49839DE59&Mode2=Video",
             "kingcounty",
             None,
-            "http://archive-media.granicus.com:443/OnDemand/king/king_80aac332-5f77"
+            "https://archive-video.granicus.com/king/king_80aac332-5f77"
             + "-43b4-9259-79d108cdbff1.mp4",
         ),
         (
@@ -21,7 +21,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             + "redirect=true&h=554d836741a2ef17c85f81f393fdd2a0",
             "milwaukee",
             None,
-            "https://archive-media2.granicus.com/OnDemand/milwaukee/"
+            "https://archive-video.granicus.com/milwaukee/"
             + "milwaukee_ab8846f8-7591-4c06-bffe-8f3953346af2.mp4",
         ),
         (
@@ -30,7 +30,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             + "redirect=true&h=061d42ee62c77b4008bd1841ecd023ad",
             "denver",
             None,
-            "http://archive-media.granicus.com:443/OnDemand/denver/"
+            "https://archive-video.granicus.com/denver/"
             + "denver_7f5b308a-1a82-48dc-8f1b-ce7767ee2e9b.mp4",
         ),
         (
@@ -39,8 +39,8 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             + "h=09f2d7e09d3f0ebcdb959f089e3f922a",
             "boston",
             "http://boston.granicus.com//videos/324/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:boston/"
-            + "boston_3260c449-dba9-4b54-8cdd-38bf31147d98.mp4/playlist.m3u8",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive"
+            + "/boston/boston_3260c449-dba9-4b54-8cdd-38bf31147d98.mp4/playlist.m3u8",
         ),
         (
             # parser3
@@ -49,7 +49,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "corpuschristi",
             "http://corpuschristi.granicus.com//videos/1694/captions.vtt",
             "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:"
-            + "corpuschristi/corpuschristi_f91b021b-b5da-45bb-b5fc"
+            + "archive/corpuschristi/corpuschristi_f91b021b-b5da-45bb-b5fc"
             + "-ec7c7d8c2d32.mp4/playlist.m3u8",
         ),
         (
@@ -58,8 +58,8 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             + "&redirect=true&h=0a4363d1c34a910f97dfc42636b53cf1",
             "elpasotexas",
             "http://elpasotexas.granicus.com//videos/224/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4"
-            + ":elpasotexas/elpasotexas_c654bf29-2d1b-4de3-826d-9c5746511f6a"
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/"
+            + "elpasotexas/elpasotexas_c654bf29-2d1b-4de3-826d-9c5746511f6a"
             + ".mp4/playlist.m3u8",
         ),
         (
@@ -67,7 +67,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://longbeach.granicus.com/MediaPlayer.php?view_id=84&clip_id=13404",
             "longbeach",
             None,
-            "http://archive-media.granicus.com:443/OnDemand/longbeach/"
+            "https://archive-video.granicus.com/longbeach/"
             + "longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4",
         ),
         (
@@ -75,7 +75,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://richmondva.granicus.com/MediaPlayer.php?view_id=1&clip_id=3271",
             "richmondva",
             None,
-            "http://archive-media.granicus.com:443/OnDemand/richmondva/"
+            "https://archive-video.granicus.com/richmondva/"
             + "richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4",
         ),
     ],

--- a/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
+++ b/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
@@ -1,8 +1,9 @@
 import pytest
 
-from cdp_backend.pipeline.ingestion_models import MinutesItem
+from cdp_backend.pipeline.ingestion_models import Matter, MinutesItem
 from cdp_scrapers.prime_gov_utils import (
     Agenda,
+    get_matter,
     get_minutes_item,
     get_support_files,
     load_agenda,
@@ -28,6 +29,21 @@ first_minutes_items = [
     ),
 ]
 support_file_counts = [4]
+matters = [
+    Matter(
+        name="Information Technology Agency report",
+        matter_type="report",
+        title=(
+            "Information Technology Agency (ITA) report, "
+            "in response to a 2022-23 Budget Recommendation, "
+            "relative to the status on the implementation "
+            "of permanent Wi-Fi hotspots."
+        ),
+        result_status="APPROVED",
+        sponsors=None,
+        external_source_id=None,
+    )
+]
 
 
 @pytest.mark.parametrize("url", urls)
@@ -63,3 +79,13 @@ def test_get_minutes_item(
 )
 def test_get_support_files(agenda: Agenda, num_files: int):
     assert len(list(get_support_files(next(get_minutes_tables(agenda))))) == num_files
+
+
+@pytest.mark.parametrize(
+    "agenda, matter",
+    zip(agendas, matters),
+)
+def test_get_matter(agenda: Agenda, matter: Matter):
+    minutes_table = next(get_minutes_tables(agenda))
+    minutes_item = get_minutes_item(minutes_table)
+    assert get_matter(minutes_table, minutes_item) == matter

--- a/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
+++ b/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
@@ -18,6 +18,7 @@ urls = [
 ]
 agendas = list(map(load_agenda, urls))
 minutes_counts = [8]
+support_file_counts = [4]
 first_minutes_items = [
     MinutesItem(
         name="22-0600-S29",
@@ -28,7 +29,6 @@ first_minutes_items = [
         ),
     ),
 ]
-support_file_counts = [4]
 matters = [
     Matter(
         name="Information Technology Agency report",
@@ -36,8 +36,7 @@ matters = [
         title=(
             "Information Technology Agency (ITA) report, "
             "in response to a 2022-23 Budget Recommendation, "
-            "relative to the status on the implementation "
-            "of permanent Wi-Fi hotspots."
+            "relative to the status on the implementation of permanent Wi-Fi hotspots."
         ),
         result_status="APPROVED",
         sponsors=None,

--- a/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
+++ b/cdp_scrapers/tests/test_prime_gov_agenda_scraper.py
@@ -1,11 +1,12 @@
 import pytest
 
+from cdp_backend.pipeline.ingestion_models import MinutesItem
 from cdp_scrapers.prime_gov_utils import (
     Agenda,
     get_minutes_item,
+    get_support_files,
     load_agenda,
     get_minutes_tables,
-    MinutesItemInfo,
 )
 
 urls = [
@@ -17,15 +18,16 @@ urls = [
 agendas = list(map(load_agenda, urls))
 minutes_counts = [8]
 first_minutes_items = [
-    MinutesItemInfo(
+    MinutesItem(
         name="22-0600-S29",
-        desc=(
+        description=(
             "Information Technology Agency (ITA) report, "
             "in response to a 2022-23 Budget Recommendation, "
             "relative to the status on the implementation of permanent Wi-Fi hotspots."
         ),
     ),
 ]
+support_file_counts = [4]
 
 
 @pytest.mark.parametrize("url", urls)
@@ -50,6 +52,14 @@ def test_get_minutes_tables(
 )
 def test_get_minutes_item(
     agenda: Agenda,
-    minutes_item: MinutesItemInfo,
+    minutes_item: MinutesItem,
 ):
     assert get_minutes_item(next(get_minutes_tables(agenda))) == minutes_item
+
+
+@pytest.mark.parametrize(
+    "agenda, num_files",
+    zip(agendas, support_file_counts),
+)
+def test_get_support_files(agenda: Agenda, num_files: int):
+    assert len(list(get_support_files(next(get_minutes_tables(agenda))))) == num_files

--- a/cdp_scrapers/tests/test_prime_gov_utils.py
+++ b/cdp_scrapers/tests/test_prime_gov_utils.py
@@ -118,8 +118,23 @@ def test_get_body(scraper: PrimeGovScraper, meetings: List[Meeting]):
     "scraper, minutes_tbls, minutes_item",
     zip(scrapers, minutes_tables, minutes_items),
 )
-def test_get_minutes_item(scraper: PrimeGovScraper, minutes_tbls: Iterator[Tag], minutes_item: MinutesItem):
+def test_get_minutes_item(
+    scraper: PrimeGovScraper, minutes_tbls: Iterator[Tag], minutes_item: MinutesItem
+):
     assert scraper.get_minutes_item(next(minutes_tbls)) == minutes_item
+
+
+@pytest.mark.parametrize(
+    "scraper, minutes_tbls, minutes_item, matter",
+    zip(scrapers, minutes_tables, minutes_items, matters),
+)
+def test_get_matter(
+    scraper: PrimeGovScraper,
+    minutes_tbls: Iterator[Tag],
+    minutes_item: MinutesItem,
+    matter: Matter,
+):
+    assert scraper.get_matter(next(minutes_tbls), minutes_item) == matter
 
 
 @pytest.mark.parametrize(

--- a/cdp_scrapers/tests/test_scrapers.py
+++ b/cdp_scrapers/tests/test_scrapers.py
@@ -94,7 +94,7 @@ def test_seattle_scraper(
             -1,
             -1,
             -1,
-            "http://archive-media.granicus.com:443/OnDemand/king/"
+            "https://archive-video.granicus.com/king/"
             "king_80aac332-5f77-43b4-9259-79d108cdbff1.mp4",
         ),
         # Check for 6 events, with the first event having 1 minute item.
@@ -108,7 +108,7 @@ def test_seattle_scraper(
             4,
             4,
             4,
-            "http://archive-media.granicus.com:443/OnDemand/king/"
+            "https://archive-video.granicus.com/king/"
             "king_b2529fca-1b29-4f3e-b0c5-aa9f4bbb27d9.mp4",
         ),
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requirements = [
 
 requirements = [
     "beautifulsoup4~=4.9",
-    "cdp-backend~=3.0",
+    "cdp-backend~=3.2.4",
     "defusedxml~=0.7.1",
     "pytz~=2021.1",
     "requests~=2.25",


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is part of #101 

### Description of Changes

`get_support_files()` and `get_matter()` implemented to allow

```Python
agenda = load_agenda(agenda_web_page_url)
item_tables = get_minutes_tables(agenda)
minutes_item = get_minutes_item(item_tables[0])
# Above already implemented

support_files = get_support_files(item_tables[0])
matter = get_matter(item_tables[0], minutes_item)

event_item = EventMinutesItem(
    matter=matter,
    minutes_item=minutes_item,
    supporting_files=support_files,
)
```
