### PR TITLE
Using dataclass_json decorator for ScraperStaticData

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Ready to contribute? Here's how to set up `cdp-scrapers` for local development.
 
     ```bash
     cd cdp-scrapers/
-    pip install -e .[dev]
+    pip install -e '.[dev]'
     ```
 
 4. Create a branch for local development:

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -17,8 +17,8 @@ from cdp_backend.pipeline.mock_get_events import (
     get_events as get_test_deployment_events,
 )
 
-from cdp_scrapers.instances.houston import get_houston_events
 from cdp_scrapers.instances.atlanta import get_events as get_atlanta_events
+from cdp_scrapers.instances.houston import get_houston_events
 from cdp_scrapers.instances.lacity import LosAngelesScraper, get_lacity_events
 from cdp_scrapers.instances.portland import get_portland_events
 from cdp_scrapers.legistar_utils import LegistarScraper

--- a/cdp_scrapers/instances/__init__.py
+++ b/cdp_scrapers/instances/__init__.py
@@ -17,8 +17,8 @@ from cdp_backend.pipeline.mock_get_events import (
     get_events as get_test_deployment_events,
 )
 
-from cdp_scrapers.instances.atlanta import get_events as get_atlanta_events
 from cdp_scrapers.instances.houston import get_houston_events
+from cdp_scrapers.instances.atlanta import get_events as get_atlanta_events
 from cdp_scrapers.instances.lacity import LosAngelesScraper, get_lacity_events
 from cdp_scrapers.instances.portland import get_portland_events
 from cdp_scrapers.legistar_utils import LegistarScraper

--- a/cdp_scrapers/instances/kingcounty-static.json
+++ b/cdp_scrapers/instances/kingcounty-static.json
@@ -63,7 +63,9 @@
             "phone": "206-477-1001",
             "website": "https://kingcounty.gov/council/dembowski.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/Dembowski_2x3_print.ashx",
-            "seat": "Position 1",
+            "seat": {
+                "name": "Position 1"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -88,7 +90,9 @@
             "phone": "206-477-1002",
             "website": "https://kingcounty.gov/council/zahilay",
             "picture_uri": "https://kingcounty.gov/~/media/council/Zahilay/Zahilay_DSC8834_2x3.ashx",
-            "seat": "Position 2",
+            "seat": {
+                "name": "Position 2"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -113,7 +117,9 @@
             "phone": "206-477-1003",
             "website": "https://kingcounty.gov/council/lambert",
             "picture_uri": "https://kingcounty.gov/~/media/Lambert/images/2019/Lambert_2020_2x3.ashx",
-            "seat": "Position 3",
+            "seat": {
+                "name": "Position 3"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -138,7 +144,9 @@
             "phone": "206-477-1003",
             "website": "https://kingcounty.gov/council/perry.aspx",
             "picture_uri": "https://kingcounty.gov/council/~/media/council/perry/KCC_SarahPerry.ashx",
-            "seat": "Position 3",
+            "seat": {
+                "name": "Position 3"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -163,7 +171,9 @@
             "phone": "206-477-1004",
             "website": "https://kingcounty.gov/council/kohl-welles.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/kohl-welles/images/2020/Kohl_Wells_2x3_print.ashx",
-            "seat": "Position 4",
+            "seat": {
+                "name": "Position 4"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -194,7 +204,9 @@
             "phone": "206-477-1005",
             "website": "https://kingcounty.gov/council/upthegrove.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/Upthegove_2x3_print.ashx",
-            "seat": "Position 5",
+            "seat": {
+                "name": "Position 5"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -219,7 +231,9 @@
             "phone": "206-477-1006",
             "website": "https://kingcounty.gov/council/balducci.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/balducci/images/2021/Balducci_highres.ashx",
-            "seat": "Position 6",
+            "seat": {
+                "name": "Position 6"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -250,7 +264,9 @@
             "phone": "206-477-1007",
             "website": "https://kingcounty.gov/council/vonreichbauer",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/2018/von_Reichbauer_2x3_print.ashx",
-            "seat": "Position 7",
+            "seat": {
+                "name": "Position 7"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -275,7 +291,9 @@
             "phone": "206-477-1008",
             "website": "https://kingcounty.gov/council/mcdermott.aspx",
             "picture_uri": "https://kingcounty.gov/~/media/council/images/joecropped.ashx",
-            "seat": "Position 8",
+            "seat": {
+                "name": "Position 8"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",
@@ -300,7 +318,9 @@
             "phone": "206-477-1009",
             "website": "https://kingcounty.gov/council/dunn",
             "picture_uri": "https://kingcounty.gov/~/media/Dunn/images/2019/Dunn_DSC8750_2x3.ashx",
-            "seat": "Position 9",
+            "seat": {
+                "name": "Position 9"
+            },
             "roles": [
                 {
                     "body": "Metropolitan King County Council",

--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -45,7 +45,9 @@
             "phone": "503-823-4120",
             "website": "https://www.portland.gov/wheeler",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2020-03/mayor-wheeler-headshot-4x5-3-5-2020.jpg",
-            "seat": "Mayor",
+            "seat": {
+                "name": "Mayor"
+            },
             "roles": [
                 {
                     "title":  "Council President",
@@ -112,7 +114,9 @@
             "phone": "503-823-3008",
             "website": "https://www.portland.gov/rubio",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/carmen-rubio.jpg",
-            "seat": "Position 1",
+            "seat": {
+                "name": "Position 1"
+            },
             "roles": [
                 {
                     "title":  "Councilmember",
@@ -155,7 +159,9 @@
             "phone": "503-823-3589",
             "website": "https://www.portland.gov/ryan",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/katalina-berbari-2_0.jpg",
-            "seat": "Position 2",
+            "seat": {
+                "name": "Position 2"
+            },
             "roles": [
                 {
                     "title":  "Councilmember",
@@ -192,7 +198,9 @@
             "phone": "503-823-4151",
             "website": "https://www.portland.gov/hardesty",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/max_540w/public/2020-01/jo-ann-hardesty-portrait-about-page.jpg",
-            "seat": "Position 3",
+            "seat": {
+                "name": "Position 3"
+            },
             "roles": [
                 {
                     "title":  "Councilmember",
@@ -235,7 +243,9 @@
             "phone": "503-823-4682",
             "website": "https://www.portland.gov/mapps",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2021/minguswattributionjpegcrop2_0.jpg",
-            "seat": "Position 4",
+            "seat": {
+                "name": "Position 4"
+            },
             "roles": [
                 {
                     "title":  "Councilmember",
@@ -272,7 +282,9 @@
             "phone": "503-823-4078",
             "website": "https://www.portland.gov/auditor/hull-caballero",
             "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_640w/public/2021/mary-hull-caballero_headshot.jpg",
-            "seat": "Auditor",
+            "seat": {
+                "name": "Auditor"
+            },
             "roles": [
                 {
                     "title":  "Councilmember",

--- a/cdp_scrapers/instances/seattle-static.json
+++ b/cdp_scrapers/instances/seattle-static.json
@@ -63,7 +63,9 @@
             "phone": "206-684-8804",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Pedersen/Councilmember-Alex-Pedersen_square-headshot.jpg",
-            "seat": "Position 4",
+            "seat": {
+                "name": "Position 4"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -87,7 +89,9 @@
             "phone": "206-684-8807",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Lewis/Andrew-Lewis-Campaign-Headshot_300x300.jpg",
-            "seat": "Position 7",
+            "seat": {
+                "name": "Position 7"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -111,7 +115,9 @@
             "phone": "206-684-8806",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Strauss/strauss_headshot_300x300.jpg",
-            "seat": "Position 6",
+            "seat": {
+                "name": "Position 6"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -135,7 +141,9 @@
             "phone": "206-684-8805",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Juarez/Debora-Juarez-2018_225x225.jpg",
-            "seat": "Position 5",
+            "seat": {
+                "name": "Position 5"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -171,7 +179,9 @@
             "phone": "206-684-8803",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Sawant/Sawant_225x225.jpg",
-            "seat": "Position 3",
+            "seat": {
+                "name": "Position 3"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -195,7 +205,9 @@
             "phone": "206-684-8801",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Herbold/Herbold_225x225.jpg",
-            "seat": "Position 1",
+            "seat": {
+                "name": "Position 1"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -214,7 +226,9 @@
         "M. Lorena Gonz\u00e1lez": {
             "name": "M. Lorena Gonz\u00e1lez",
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Gonzalez/Lorena-González_2020-headshot_225x225.jpg",
-            "seat": "Position 9",
+            "seat": {
+                "name": "Position 9"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -250,7 +264,9 @@
             "phone": "206-684-8809",
             "website": null,
             "picture_uri": "https://www.seattle.gov/images/Council/Members/Nelson/nelson_300x300.jpg",
-            "seat": "Position 9",
+            "seat": {
+                "name": "Position 9"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -274,7 +290,9 @@
             "phone": "206-684-8802",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Morales/Tammy-Morales_headshot_final_300x300.jpg",
-            "seat": "Position 2",
+            "seat": {
+                "name": "Position 2"
+            },
             "roles": [
                 {
                     "body": "City Council",
@@ -298,7 +316,9 @@
             "phone": "206-684-8808",
             "website": null,
             "picture_uri": "https://www.seattle.gov/assets/Images/Council/Members/Mosqueda/Mosqueda_225x225.jpg",
-            "seat": "Position 8",
+            "seat": {
+                "name": "Position 8"
+            },
             "roles": [
                 {
                     "body": "City Council",

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -73,10 +73,9 @@ class SeattleScraper(LegistarScraper):
 
         try:
             url = "https://seattlechannel.org/"
-            urlopen("https://seattlechannel.org/")
+            urlopen(url)
         except URLError as ue:
-            log.error(f"Unable to reach {url}", ue)
-            return
+            raise Exception(f"Unable to reach {url}: {ue}")
 
     def parse_content_uris(
         self, video_page_url: str, event_short_date: str

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -311,10 +311,7 @@ class SeattleScraper(LegistarScraper):
         # href attribute that contains videoid
 
         soup = BeautifulSoup(response, "html.parser")
-        for link in soup.find(
-            "div",
-            class_="paginationContainer",
-        ).find_all(
+        for link in soup.find("div", class_="paginationContainer",).find_all(
             "a",
             href=re.compile("videoid"),
             onclick=re.compile("loadJWPlayer"),

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -72,14 +72,11 @@ class SeattleScraper(LegistarScraper):
         )
 
         try:
+            url = "https://seattlechannel.org/"
             urlopen("https://seattlechannel.org/")
-        except URLError:
-            pass
-        else:
-            raise Exception(
-                "seattlechannel.org may have fixed their SSL cert. "
-                "Check and fix 'requests.get(*, verify=False)' calls"
-            )
+        except URLError as ue:
+            log.error(f"Unable to reach {url}", ue)
+            return
 
     def parse_content_uris(
         self, video_page_url: str, event_short_date: str

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -307,7 +307,10 @@ class SeattleScraper(LegistarScraper):
         # href attribute that contains videoid
 
         soup = BeautifulSoup(response, "html.parser")
-        for link in soup.find("div", class_="paginationContainer",).find_all(
+        for link in soup.find(
+            "div",
+            class_="paginationContainer",
+        ).find_all(
             "a",
             href=re.compile("videoid"),
             onclick=re.compile("loadJWPlayer"),

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -307,10 +307,7 @@ class SeattleScraper(LegistarScraper):
         # href attribute that contains videoid
 
         soup = BeautifulSoup(response, "html.parser")
-        for link in soup.find(
-            "div",
-            class_="paginationContainer",
-            ).find_all(
+        for link in soup.find("div", class_="paginationContainer",).find_all(
             "a",
             href=re.compile("videoid"),
             onclick=re.compile("loadJWPlayer"),

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -308,7 +308,10 @@ class SeattleScraper(LegistarScraper):
         # href attribute that contains videoid
 
         soup = BeautifulSoup(response, "html.parser")
-        for link in soup.find("div", class_="paginationContainer",).find_all(
+        for link in soup.find(
+            "div",
+            class_="paginationContainer",
+            ).find_all(
             "a",
             href=re.compile("videoid"),
             onclick=re.compile("loadJWPlayer"),

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -1,4 +1,3 @@
-import json
 import re
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -187,33 +186,8 @@ def parse_static_file(file_path: Path) -> ScraperStaticData:
     -----
     Function looks for "seats", "primary_bodies", "persons" top-level keys
     """
-    with open(file_path) as static_file:
-        static_json = json.load(static_file)
-        seats = static_json["seats"]
-        persons = dict(dict(static_json)["persons"])
-        primary_bodies = static_json["primary_bodies"]
-
-        # This is necessary for deserialization
-        # as "name" is a required field in Seat class.
-        for k in persons:
-            if "name" not in persons[k]["seat"]:
-                # assuming that the original persons[k]["seat"] 
-                # is a single string (like Mayor, etc).
-                persons[k]["seat"] = {"name": persons[k]["seat"]}
-
-        static_json = {
-            "seats": seats,
-            "persons": persons,
-            "primary_bodies": primary_bodies,
-        }
-        log.debug(
-            f"ScraperStaticData parsed from {file_path}:\n"
-            f"    seats: {list(seats.keys())}\n"
-            f"    primary_bodies: {list(primary_bodies.keys())}\n"
-            f"    persons: {list(persons.keys())}\n"
-        )
-
-        return ScraperStaticData.from_dict(static_json)
+    with open(file_path, "r") as static_file:
+        return ScraperStaticData.from_json(static_file.read())
 
 
 def sanitize_roles(

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -197,7 +197,8 @@ def parse_static_file(file_path: Path) -> ScraperStaticData:
         # as "name" is a required field in Seat class.
         for k in persons:
             if "name" not in persons[k]["seat"]:
-                # assuming that the original persons[k]["seat"] is a single string (like Mayor, etc).
+                # assuming that the original persons[k]["seat"] 
+                # is a single string (like Mayor, etc).
                 persons[k]["seat"] = {"name": persons[k]["seat"]}
 
         static_json = {
@@ -205,7 +206,6 @@ def parse_static_file(file_path: Path) -> ScraperStaticData:
             "persons": persons,
             "primary_bodies": primary_bodies,
         }
-        
         log.debug(
             f"ScraperStaticData parsed from {file_path}:\n"
             f"    seats: {list(seats.keys())}\n"

--- a/cdp_scrapers/tests/legistar_content_parser_test.py
+++ b/cdp_scrapers/tests/legistar_content_parser_test.py
@@ -67,7 +67,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://longbeach.granicus.com/MediaPlayer.php?view_id=84&clip_id=13404",
             "longbeach",
             "http://longbeach.granicus.com//videos/13404/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/"
             + "longbeach/longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/"
             + "playlist.m3u8",
         ),
@@ -76,7 +76,7 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://richmondva.granicus.com/MediaPlayer.php?view_id=1&clip_id=3271",
             "richmondva",
             "http://richmondva.granicus.com//videos/3271/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/"
             + "richmondva/richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/"
             + "playlist.m3u8",
         ),

--- a/cdp_scrapers/tests/legistar_content_parser_test.py
+++ b/cdp_scrapers/tests/legistar_content_parser_test.py
@@ -66,17 +66,16 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             # parser4
             "https://longbeach.granicus.com/MediaPlayer.php?view_id=84&clip_id=13404",
             "longbeach",
-            None,
-            "https://archive-video.granicus.com/longbeach/"
-            + "longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4",
+            "http://longbeach.granicus.com//videos/13404/captions.vtt",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/longbeach/"
+            + "longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/playlist.m3u8"
         ),
         (
             # parser4
             "https://richmondva.granicus.com/MediaPlayer.php?view_id=1&clip_id=3271",
             "richmondva",
-            None,
-            "https://archive-video.granicus.com/richmondva/"
-            + "richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4",
+            "http://richmondva.granicus.com//videos/3271/captions.vtt",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/richmondva/richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/playlist.m3u8",
         ),
     ],
 )

--- a/cdp_scrapers/tests/legistar_content_parser_test.py
+++ b/cdp_scrapers/tests/legistar_content_parser_test.py
@@ -67,15 +67,18 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://longbeach.granicus.com/MediaPlayer.php?view_id=84&clip_id=13404",
             "longbeach",
             "http://longbeach.granicus.com//videos/13404/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/longbeach/"
-            + "longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/playlist.m3u8"
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/",
+            + "longbeach/longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/"
+            + "playlist.m3u8",
         ),
         (
             # parser4
             "https://richmondva.granicus.com/MediaPlayer.php?view_id=1&clip_id=3271",
             "richmondva",
             "http://richmondva.granicus.com//videos/3271/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/richmondva/richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/playlist.m3u8",
+            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive/",
+            + "richmondva/richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/"
+            + "playlist.m3u8",
         ),
     ],
 )

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional
 
 from bs4 import BeautifulSoup
 from cdp_backend.pipeline.ingestion_models import Body, Person, Seat
-from dataclasses_json import dataclass_json
+from dataclasses_json import DataClassJsonMixin
 
 ###############################################################################
 
@@ -16,9 +16,8 @@ class ContentURIs(NamedTuple):
     caption_uri: Optional[str] = None
 
 
-@dataclass_json
 @dataclass
-class ScraperStaticData:
+class ScraperStaticData(DataClassJsonMixin):
     seats: Dict[str, Seat] = None
     primary_bodies: Dict[str, Body] = None
     persons: Dict[str, Person] = None

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from dataclasses import dataclass
 from typing import Callable, Dict, List, NamedTuple, Optional
 
 from bs4 import BeautifulSoup
 from cdp_backend.pipeline.ingestion_models import Body, Person, Seat
+from dataclasses_json import dataclass_json
 
 ###############################################################################
 
@@ -14,7 +16,9 @@ class ContentURIs(NamedTuple):
     caption_uri: Optional[str] = None
 
 
-class ScraperStaticData(NamedTuple):
+@dataclass_json
+@dataclass
+class ScraperStaticData:
     seats: Dict[str, Seat] = None
     primary_bodies: Dict[str, Body] = None
     persons: Dict[str, Person] = None


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue
https://github.com/CouncilDataProject/cdp-scrapers/issues/91

### Description of Changes
This change leverages use of `dataclass_json` decorator to provide deserialization capability to `ScraperStaticData`. Along with that, a function that deserializes `ScraperStaticData` was refactored to use `ScraperStaticData.from_dict()`

### Testing
No additional tests were added, but the existing tests verifies the modified code path.
Test results remain the same with or without the change.
```
cdp_scrapers/tests/legistar_content_parser_test.py ......FF                                              [ 17%]
cdp_scrapers/tests/test_prime_gov_agenda_scraper.py .....                                                [ 28%]
cdp_scrapers/tests/test_prime_gov_utils.py ...............                                               [ 60%]
cdp_scrapers/tests/test_scraper_utils.py .......                                                         [ 76%]
cdp_scrapers/tests/test_scrapers.py ..FF.......                                                          [100%]
```