### PR TITLE
bugfix/pipeline-fixes

### DIFF
--- a/cdp_scrapers/instances/kingcounty.py
+++ b/cdp_scrapers/instances/kingcounty.py
@@ -53,7 +53,9 @@ class KingCountyScraper(LegistarScraper):
                 "This is a mandatory referral to the",
                 "Watch King County TV Channel 22",
             ],
-            static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
+            static_data=parse_static_file(
+                STATIC_FILE_DEFAULT_PATH, "America/Los_Angeles"
+            ),
             role_replacements={
                 "Boardmember": RoleTitle.MEMBER,
                 "Mr.": RoleTitle.MEMBER,

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -39,7 +39,9 @@ log = logging.getLogger(__name__)
 
 ###############################################################################
 
-SCRAPER_STATIC_DATA = parse_static_file(Path(__file__).parent / "portland-static.json")
+SCRAPER_STATIC_DATA = parse_static_file(
+    Path(__file__).parent / "portland-static.json", "America/Los_Angeles"
+)
 
 ###############################################################################
 

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -64,7 +64,9 @@ class SeattleScraper(LegistarScraper):
                 r".+:$",
                 "Pursuant to Washington State",
             ],
-            static_data=parse_static_file(STATIC_FILE_DEFAULT_PATH),
+            static_data=parse_static_file(
+                STATIC_FILE_DEFAULT_PATH, "America/Los_Angeles"
+            ),
             person_aliases=PERSON_ALIASES,
         )
 

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from copy import deepcopy
 from datetime import datetime, timedelta
 from itertools import filterfalse, groupby
@@ -83,9 +84,9 @@ def str_simplified(input_str: str) -> str:
 
 
 def parse_static_person(
-    person_json: Dict[str, Any],
-    all_seats: Dict[str, Seat],
-    primary_bodies: Dict[str, Body],
+    person_json: dict[str, Any],
+    all_seats: dict[str, Seat],
+    primary_bodies: dict[str, Body],
     timezone: pytz.timezone,
 ) -> Person:
     """
@@ -104,6 +105,11 @@ def parse_static_person(
     primary_bodies: Dict[str, Body]
         Bodies defined as top-level in static data file.
 
+    timezone: str
+        The timezone for the target client.
+        i.e. "America/Los_Angeles" or "America/New_York"
+        See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for canonical
+        timezones.
 
     See Also
     --------
@@ -154,7 +160,7 @@ def parse_static_person(
             except Exception:
                 pass
             else:
-                raise NotImplementedError("We can resume using from_dict")
+                log.info(f"We can resume using from_dict ({sys.version_info})")
 
             dt_val = kwargs.get("start_datetime")
             kwargs["start_datetime"] = (
@@ -189,12 +195,18 @@ def parse_static_person(
 
 def parse_static_file(file_path: Path, timezone: str) -> ScraperStaticData:
     """
-    Parse Seats, Bodies and Persons from static data JSON
+    Parse Seats, Bodies and Persons from static data JSON.
 
     Parameters
     ----------
     file_path: Path
         Path to file containing static data in JSON
+
+    timezone: str
+        The timezone for the target client.
+        i.e. "America/Los_Angeles" or "America/New_York"
+        See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for canonical
+        timezones.
 
     Returns
     -------
@@ -211,29 +223,29 @@ def parse_static_file(file_path: Path, timezone: str) -> ScraperStaticData:
     Function looks for "seats", "primary_bodies", "persons" top-level keys
     """
     with open(file_path) as static_file:
-        static_json: Dict[str, Dict[str, Any]] = json.load(static_file)
+        static_json: dict[str, dict[str, Any]] = json.load(static_file)
 
         if "seats" not in static_json:
-            seats: Dict[str, Seat] = {}
+            seats: dict[str, Seat] = {}
         else:
-            seats: Dict[str, Seat] = {
+            seats: dict[str, Seat] = {
                 seat_name: Seat(**seat)
                 for seat_name, seat in static_json["seats"].items()
             }
 
         if "primary_bodies" not in static_json:
-            primary_bodies: Dict[str, Body] = {}
+            primary_bodies: dict[str, Body] = {}
         else:
-            primary_bodies: Dict[str, Body] = {
+            primary_bodies: dict[str, Body] = {
                 body_name: Body(**body)
                 for body_name, body in static_json["primary_bodies"].items()
             }
 
         if "persons" not in static_json:
-            known_persons: Dict[str, Person] = {}
+            known_persons: dict[str, Person] = {}
         else:
             timezone = pytz.timezone(timezone)
-            known_persons: Dict[str, Person] = {
+            known_persons: dict[str, Person] = {
                 person_name: parse_static_person(
                     person, seats, primary_bodies, timezone
                 )

--- a/cdp_scrapers/tests/legistar_content_parser_test.py
+++ b/cdp_scrapers/tests/legistar_content_parser_test.py
@@ -67,20 +67,26 @@ from cdp_scrapers.legistar_utils import parse_video_page_url
             "https://longbeach.granicus.com/MediaPlayer.php?view_id=84&clip_id=13404",
             "longbeach",
             "http://longbeach.granicus.com//videos/13404/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive"
-            "/longbeach/longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/playlist.m3u8",
+            (
+                "https://archive-stream.granicus.com/"
+                "OnDemand/_definst_/mp4:archive/longbeach/"
+                "longbeach_cf37b162-9817-428a-9fcd-b72daca8062a.mp4/playlist.m3u8"
+            ),
         ),
         (
             # parser4
             "https://richmondva.granicus.com/MediaPlayer.php?view_id=1&clip_id=3271",
             "richmondva",
             "http://richmondva.granicus.com//videos/3271/captions.vtt",
-            "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:archive"
-            "/richmondva/richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/playlist.m3u8",
+            (
+                "https://archive-stream.granicus.com/"
+                "OnDemand/_definst_/mp4:archive/richmondva/"
+                "richmondva_870c84ae-9614-44a3-a65b-a3e79c56426d.mp4/playlist.m3u8"
+            ),
         ),
     ],
 )
-def test_str_simplifed(
+def test_parse_video_page_url(
     video_page_url: str, client: str, expected_caption_uri: str, expected_video_uri: str
 ):
     assert (


### PR DESCRIPTION
### Link to Relevant Issue

This should fix at least parts of the CI/CD errors.

First, I wanted to change typing syntax in upstream `cdp-backend` ingestion model class definitions, but that does not fix the problem fully. After changing them to e.g. `Union[str, None] = None`, Python further complains `type` objects are not subscriptable. _Completely_ removing typing does resolve _that_ issue, but then e.g. `Seat` does not recognize `roles` keyword. It's just a mess.

Given everything, I think just using key-value constructor for the ingestion objects is a reasonable (even "best") compromise for the time being.

### Description of Changes

- Create ingestion model objects from static data file by passing the dictionary as key-value pairs into the class constructors.
- Updated some test data to reflect up-to-date information provided by the municipalities.
- Code to `raise` when `from_dict` does succeed again; though we may move away from `dataclasses_json`.