### PR TITLE
bugfix/handle-legistar-site-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ seattle_cdp_parsed_events = get_seattle_events(
 
 #### Event Scraper Structure
 
-![get_events](./images/get_events.png)
-
-Our current event scraper structure is as shown above. The main function `get_events` 
+Our current event scraper structure is as follows. The main function `get_events` 
 gets all the required data and it calls the `get_content_uris` function to return the 
 required video data.
 

--- a/cdp_scrapers/finding_legistar_id.md
+++ b/cdp_scrapers/finding_legistar_id.md
@@ -11,8 +11,7 @@ isn’t always easily discoverable so here are some steps to find it.
 2. Look at the URL of the website and if it contains “legistar”, then your 
 municipality uses Legistar. If it does not, your municipality likely does not use 
 Legistar and you should review step three for another method for determining if your 
-municipality utilizes Legistar.  
-![Legistar ID for Seattle](./images/seattle_legistar_url.png)
+municipality utilizes Legistar.
 
 3. If step 2 fails, try an online search with query words such as “Legistar 
 municipality council agendas”. If your municipality uses Legistar, the top search 

--- a/cdp_scrapers/instances/atlanta.py
+++ b/cdp_scrapers/instances/atlanta.py
@@ -17,8 +17,8 @@ def get_single_person(driver: "WebDriver", member_name: str) -> ingestion_models
     Get all the information fot one person
     Includes: role, seat, picture, phone, email.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:
         webdriver calling the people's dictionary page
     member_name:
@@ -136,8 +136,8 @@ def get_new_person(name: str) -> ingestion_models.Person:
     """
     Creates the person ingestion model for the people that are not recored.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     name:str
         the name of the person
 
@@ -154,8 +154,8 @@ def convert_status_constant(decision: str) -> str:
     """
     Converts the matter result status to the exsiting constants.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     decision: str
         decision of the matter
 
@@ -193,8 +193,8 @@ def assign_constant(
     """
     Assign constants and add Vote to the ingestion models based on the vote decision.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         webdriver of the matter page
     i: int
@@ -269,8 +269,8 @@ def get_voting_result(
     """
     Scrapes and converts the voting decisions to the exsiting constants.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         webdriver of the matter page
     sub_sections_len: int
@@ -332,8 +332,8 @@ def get_matter_status(driver: "WebDriver", i: int) -> Tuple[list, str]:
     """
     Find the matter result status.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         webdriver of the matter page
     i: int
@@ -366,7 +366,7 @@ def get_matter_status(driver: "WebDriver", i: int) -> Tuple[list, str]:
     return sub_sections, status_constant
 
 
-def parse_single_matter(  # noqa: C901
+def parse_single_matter(  # noqa: C901 D417
     driver: "WebDriver",
     test: str,
     item: str,
@@ -377,8 +377,8 @@ def parse_single_matter(  # noqa: C901
     """
     Get the minute items that contains a matter.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         webdriver of the matter page
     matter:element
@@ -539,8 +539,8 @@ def parse_event(  # noqa: C901
     """
     Scrapes all the information for a meeting.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     url:str
         the url of the meeting that we want to scrape
 
@@ -727,12 +727,14 @@ def get_year(driver: "WebDriver", url: str, from_dt: datetime) -> str:
     """
     Navigate to the year that we are looking for.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         empty webdriver
     url:str
         the url of the calender page
+    from_dt:datetime
+        the datetime object for the search target year
 
     Returns
     -------
@@ -760,15 +762,15 @@ def get_date(
     """
     Get a list of ingestion models for the meetings hold during the selected time range.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     driver:webdriver
         empty webdriver
     url:str
         the url of the calender page
     from_dt:
         the begin date
-    to_date:
+    to_dt:
         the end date
 
     Returns
@@ -805,11 +807,11 @@ def get_events(from_dt: datetime, to_dt: datetime) -> list:
     gets the right calender link
     feed it to the function that get a list of ingestion models.
 
-    Parameter:
-    ----------------
+    Parameters
+    ----------
     from_dt:
         the begin date
-    to_date:
+    to_dt:
         the end date
 
     Returns

--- a/cdp_scrapers/instances/houston.py
+++ b/cdp_scrapers/instances/houston.py
@@ -20,8 +20,8 @@ class HoustonScraper(IngestionModelScraper):
         """
         Remove types that are not useful.
 
-        Parameter:
-        ----------------
+        Parameters
+        ----------
         element: Union[Tag, NavigableString, None]
             The element in the page that we want to scrape
 
@@ -38,8 +38,8 @@ class HoustonScraper(IngestionModelScraper):
         """
         Get the body name for an event.
 
-        Parameter:
-        ----------------
+        Parameters
+        ----------
         event: Union[Tag, NavigableString, None]
             All elements in the page that we want to scrape
 
@@ -63,8 +63,8 @@ class HoustonScraper(IngestionModelScraper):
         """
         Parse the page and gather the event minute items.
 
-        Parameter:
-        ----------------
+        Parameters
+        ----------
         event: Union[Tag, NavigableString, None]
             All elements in the page that we want to scrape
 

--- a/cdp_scrapers/instances/portland.py
+++ b/cdp_scrapers/instances/portland.py
@@ -403,7 +403,7 @@ class PortlandScraper(IngestionModelScraper):
 
         See Also
         --------
-        make_efile_url()
+        make_efile_url
         """
         try:
             # on the event page, event minute item titles are listed

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -103,7 +103,7 @@ class SeattleScraper(LegistarScraper):
 
         See Also
         --------
-        get_content_uris()
+        get_content_uris
         """
         with warnings.catch_warnings():
             warnings.simplefilter(
@@ -270,7 +270,7 @@ class SeattleScraper(LegistarScraper):
 
         See Also
         --------
-        get_content_uris()
+        get_content_uris
         """
         with warnings.catch_warnings():
             warnings.simplefilter(
@@ -358,7 +358,7 @@ class SeattleScraper(LegistarScraper):
 
         See Also
         --------
-        parse_content_uris()
+        parse_content_uris
 
         Notes
         -----
@@ -601,7 +601,7 @@ class SeattleScraper(LegistarScraper):
 
         See Also
         --------
-        LegistarScraper.inject_known_data()
+        LegistarScraper.inject_known_data
         """
         static_person_info = {}
         for person in SeattleScraper.get_static_person_info():

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -464,7 +464,7 @@ def get_legistar_content_uris(client: str, legistar_ev: dict) -> ContentUriScrap
 
     See Also
     --------
-    LegistarScraper.get_content_uris()
+    LegistarScraper.get_content_uris
     cdp_scrapers.legistar_content_parsers
     """
     global video_page_parser
@@ -900,7 +900,7 @@ class LegistarScraper(IngestionModelScraper):
 
         See Also
         --------
-        get_legistar_body()
+        get_legistar_body
         """
         if not legistar_body:
             return None
@@ -1068,7 +1068,7 @@ class LegistarScraper(IngestionModelScraper):
 
         See Also
         --------
-        get_legistar_person()
+        get_legistar_person
         """
         if (
             not legistar_person
@@ -1428,7 +1428,7 @@ class LegistarScraper(IngestionModelScraper):
 
         See Also
         --------
-        scraper_utils.sanitize_roles()
+        scraper_utils.sanitize_roles
         """
         try:
             known_person = self.static_data.persons[person.name]

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -10,9 +10,8 @@ from datetime import datetime, timedelta
 from json import JSONDecodeError
 from typing import Any, NamedTuple
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlsplit
 from urllib.request import urlopen
-from urllib.parse import urlsplit
 
 import requests
 from bs4 import BeautifulSoup
@@ -492,18 +491,19 @@ def get_legistar_content_uris(client: str, legistar_ev: dict) -> ContentUriScrap
         with urlopen(legistar_ev[LEGISTAR_EV_SITE_URL]) as resp:
             soup = BeautifulSoup(resp.read(), "html.parser")
 
+            if "server error" in soup.text.lower():
+                try:
+                    url_attrs = urlsplit(legistar_ev[LEGISTAR_EV_SITE_URL])
+                    netloc = url_attrs.netloc
+                except ValueError:
+                    netloc = legistar_ev[LEGISTAR_EV_SITE_URL]
+                raise Exception(
+                    f"{netloc} appears to be down: {str_simplified(soup.text)}"
+                )
+
     except (URLError, HTTPError) as e:
         log.debug(f"{legistar_ev[LEGISTAR_EV_SITE_URL]}: {str(e)}")
         return (ContentUriScrapeResult.Status.ResourceAccessError, None)
-
-    if "server error" in soup.text.lower():
-        try:
-            url_attrs = urlsplit(legistar_ev[LEGISTAR_EV_SITE_URL])
-            netloc = url_attrs.netloc
-        except ValueError:
-            netloc = legistar_ev[LEGISTAR_EV_SITE_URL]
-
-        raise URLError(f"{netloc} appears to be down: {str_simplified(soup.text)}")
 
     # this gets us the url for the web PAGE containing the video
     # video link is provided in the window.open()command inside onclick event

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -459,7 +459,7 @@ def get_legistar_content_uris(client: str, legistar_ev: dict) -> ContentUriScrap
     NotImplementedError
         Means the content structure of the web page hosting session video has changed.
         We need explicit review and update the scraping code.
-    URLError
+    ConnectionError
         When the Legistar site (e.g. *.legistar.com) itself may be down.
 
     See Also
@@ -497,7 +497,7 @@ def get_legistar_content_uris(client: str, legistar_ev: dict) -> ContentUriScrap
                     netloc = url_attrs.netloc
                 except ValueError:
                     netloc = legistar_ev[LEGISTAR_EV_SITE_URL]
-                raise Exception(
+                raise ConnectionError(
                     f"{netloc} appears to be down: {str_simplified(soup.text)}"
                 )
 

--- a/cdp_scrapers/prime_gov_utils.py
+++ b/cdp_scrapers/prime_gov_utils.py
@@ -61,7 +61,7 @@ def primegov_strftime(dt: datetime) -> str:
 
     See Also
     --------
-    civic_scraper.platforms.primegov.site.PrimeGovSite.scrape()
+    civic_scraper.platforms.primegov.site.PrimeGovSite.scrape
     """
     return dt.strftime(DATE_FORMAT)
 
@@ -167,7 +167,7 @@ def get_minutes_item(minutes_table: Tag) -> MinutesItem:
 
     See Also
     --------
-    get_minutes_tables()
+    get_minutes_tables
     """
     rows = minutes_table.find_all("tr")
 
@@ -224,7 +224,7 @@ def get_support_files(minutes_table: Tag) -> Iterator[SupportingFile]:
 
     See Also
     --------
-    get_minutes_tables()
+    get_minutes_tables
     """
 
     def extract_file(file_div: Tag) -> SupportingFile:
@@ -288,7 +288,7 @@ def get_matter(  # noqa: C901
 
     See Also
     --------
-    get_minutes_tables()
+    get_minutes_tables
     """
     # ex 1. APPROVED Information Technology Agency report dated July 26, 2022
     #       - (3) Yes; (0) No
@@ -486,7 +486,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_minutes_item()
+        get_minutes_item
         """
         return self.get_none_if_empty(get_minutes_item(minutes_table))
 
@@ -516,7 +516,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
         See Also
         --------
         matter_status_pattern_map
-        get_matter()
+        get_matter
         """
 
         def _standardize_type(matter: Matter) -> Matter:
@@ -559,9 +559,9 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_matter()
-        get_minutes_item()
-        get_support_files()
+        get_matter
+        get_minutes_item
+        get_support_files
         """
 
         def _get_index(minutes_table: Tag) -> Optional[int]:
@@ -611,7 +611,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_event_minutes_item()
+        get_event_minutes_item
         """
 
         def _get_output_id(output_docs: List[Dict]) -> int:
@@ -687,8 +687,8 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_body()
-        get_session()
+        get_body
+        get_session
         """
         return self.get_none_if_empty(
             EventIngestionModel(
@@ -726,7 +726,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_events()
+        get_events
         """
         resp = self.session.get(
             API_URL.format(
@@ -759,7 +759,7 @@ class PrimeGovScraper(PrimeGovSite, IngestionModelScraper):
 
         See Also
         --------
-        get_meetings()
+        get_meetings
         """
         if end is None:
             end = datetime.utcnow()

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -113,8 +113,8 @@ def parse_static_person(  # noqa: C901
 
     See Also
     --------
-    parse_static_file()
-    sanitize_roles()
+    parse_static_file
+    sanitize_roles
     """
     log.debug(f"Begin parsing static data for {person_json['name']}")
 
@@ -215,8 +215,8 @@ def parse_static_file(file_path: Path, timezone: str) -> ScraperStaticData:
 
     See Also
     --------
-    parse_static_person()
-    sanitize_roles()
+    parse_static_person
+    sanitize_roles
 
     Notes
     -----

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -39,5 +39,5 @@ uris: Optional[List[ContentURIs]]
 See Also
 --------
 cdp_scrapers.legistar_content_parsers
-cdp_scrapers.legistar_utils.get_legistar_content_uris()
+cdp_scrapers.legistar_utils.get_legistar_content_uris
 """


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves https://github.com/CouncilDataProject/pittsburgh-pa/actions/runs/4393000564/jobs/7693148694

### Description of Changes

The Legistar web site itself for [Pittsburgh, PA is down](https://pittsburgh.legistar.com/). So obviously, the scraper is unable to scrape video URLs.

This PR allows the Legistar scraper to recognize it as web site access error.