### PR TITLE
feature/detect-persons-changes

### DIFF
--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -282,6 +282,23 @@
                 }
             ],
             "external_source_id": null
+        },
+        "Rene Gonzalez": {
+            "name": "Rene Gonzalez",
+            "is_active": true,
+            "email": "gonzalezoffice@portlandoregon.gov",
+            "phone": "503-823-4151",
+            "website": "https://www.portland.gov/gonzalez",
+            "picture_uri": "https://www.portland.gov/sites/default/files/styles/4x5_320w/public/2022/rene-headshot-1cropped_0.jpg?itok=fIOTpP8t",
+            "seat": "Position 3",
+            "roles": [
+                {
+                    "title":  "Councilmember",
+                    "start_datetime": 1672560000,
+                    "end_datetime": 1798704000,
+                    "body": "City Council"
+                }
+            ]
         }
     }
 }

--- a/cdp_scrapers/instances/portland-static.json
+++ b/cdp_scrapers/instances/portland-static.json
@@ -160,7 +160,7 @@
                 {
                     "title":  "Councilmember",
                     "start_datetime": 1599721200,
-                    "end_datetime": 1672473600,
+                    "end_datetime": 1798704000,
                     "body": "City Council"
                 },
                 {
@@ -178,8 +178,26 @@
                 {
                     "title":  "Member",
                     "start_datetime": 1599721200,
-                    "end_datetime": 1672473600,
+                    "end_datetime": 1798704000,
                     "body": {"name": "Children's Levy"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1672560000,
+                    "end_datetime": 1798704000,
+                    "body": {"name": "Community and Civic Life"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1672560000,
+                    "end_datetime": 1798704000,
+                    "body": {"name": "Equity and Human Rights"}
+                },
+                {
+                    "title":  "Member",
+                    "start_datetime": 1672560000,
+                    "end_datetime": 1798704000,
+                    "body": {"name": "Parks & Recreation"}
                 }
             ],
             "external_source_id": null

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 import json
 import logging
 import re
 import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, quote_plus, urlsplit
 from urllib.request import urlopen
@@ -84,7 +85,7 @@ class SeattleScraper(LegistarScraper):
 
     def parse_content_uris(
         self, video_page_url: str, event_short_date: str
-    ) -> List[ContentURIs]:
+    ) -> list[ContentURIs]:
         """
         Return URLs for videos and captions parsed from seattlechannel.org web page.
 
@@ -249,7 +250,7 @@ class SeattleScraper(LegistarScraper):
 
     def get_video_page_urls(
         self, video_list_page_url: str, event_short_date: str
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Return URLs to web pages hosting videos for meetings from event_short_date.
 
@@ -302,7 +303,7 @@ class SeattleScraper(LegistarScraper):
         # </div>
         #    <div class="row borderBottomNone paginationItem">
 
-        session_video_page_urls: Dict[int, str] = {}
+        session_video_page_urls: dict[int, str] = {}
 
         # want <a> tag in the <div> with
         # title attribute that contains the event date,
@@ -342,7 +343,7 @@ class SeattleScraper(LegistarScraper):
             for session in sorted(session_video_page_urls.keys())
         ]
 
-    def get_content_uris(self, legistar_ev: Dict) -> List[ContentURIs]:
+    def get_content_uris(self, legistar_ev: dict) -> list[ContentURIs]:
         """
         Return URLs for videos and captions parsed from seattlechannel.org web page.
 
@@ -429,8 +430,31 @@ class SeattleScraper(LegistarScraper):
             for uris in self.parse_content_uris(page_url, event_short_date)
         ]
 
+    # def handle_old_new_council(
+    #     self, old_names: list[str], new_names: list[str]
+    # ) -> None:
+    #     """
+    #     Raise on members change
+
+    #     Parameters
+    #     ----------
+    #     old_names: list[str]
+    #         e.g. from scraper_utils.compare_persons
+    #     new_names: list[str]
+    #         e.g. from scraper_utils.compare_persons
+
+    #     Notes
+    #     -----
+    #     Remove this function if this becomes too disruptive with false positives.
+    #     The base implementation in IngestionModelScraper will simply log.
+    #     """
+    #     if any(old_names) or any(new_names):
+    #         raise NotImplementedError(
+    #             f"Update seattle-static.json for: {old_names + new_names}"
+    #     )
+
     @staticmethod
-    def get_person_picture_url(person_www: str) -> Optional[str]:
+    def get_person_picture_url(person_www: str) -> str | None:
         """
         Parse person_www and return banner image used on the web page.
 
@@ -471,7 +495,7 @@ class SeattleScraper(LegistarScraper):
         return None
 
     @staticmethod
-    def get_static_person_info() -> Optional[List[Person]]:  # noqa: C901
+    def get_static_person_info() -> list[Person] | None:  # noqa: C901
         """
         Return partial Persons with static long-term information.
 
@@ -487,7 +511,7 @@ class SeattleScraper(LegistarScraper):
             log.debug("Failed to open https://seattle.legistar.com/MainBody.aspx")
             return None
 
-        static_person_info: List[Person] = []
+        static_person_info: list[Person] = []
 
         # <tr id="ctl00_ContentPlaceHolder1_gridPeople_ctl00__0" ...>
         #     <td class="rgSorted" style="white-space:nowrap;">

--- a/cdp_scrapers/instances/seattle.py
+++ b/cdp_scrapers/instances/seattle.py
@@ -430,29 +430,6 @@ class SeattleScraper(LegistarScraper):
             for uris in self.parse_content_uris(page_url, event_short_date)
         ]
 
-    # def handle_old_new_council(
-    #     self, old_names: list[str], new_names: list[str]
-    # ) -> None:
-    #     """
-    #     Raise on members change
-
-    #     Parameters
-    #     ----------
-    #     old_names: list[str]
-    #         e.g. from scraper_utils.compare_persons
-    #     new_names: list[str]
-    #         e.g. from scraper_utils.compare_persons
-
-    #     Notes
-    #     -----
-    #     Remove this function if this becomes too disruptive with false positives.
-    #     The base implementation in IngestionModelScraper will simply log.
-    #     """
-    #     if any(old_names) or any(new_names):
-    #         raise NotImplementedError(
-    #             f"Update seattle-static.json for: {old_names + new_names}"
-    #     )
-
     @staticmethod
     def get_person_picture_url(person_www: str) -> str | None:
         """

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1604,7 +1604,9 @@ class LegistarScraper(IngestionModelScraper):
             and any(self.static_data.persons)
             and any(self.static_data.primary_bodies)
         ):
-            have_primary_events = any(filter(lambda e: e.body.name in self.static_data.primary_bodies, events))
+            have_primary_events = any(
+                filter(lambda e: e.body.name in self.static_data.primary_bodies, events)
+            )
             if have_primary_events:
                 persons = extract_persons(events)
                 old_new = compare_persons(

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -1604,15 +1604,17 @@ class LegistarScraper(IngestionModelScraper):
             and any(self.static_data.persons)
             and any(self.static_data.primary_bodies)
         ):
-            persons = extract_persons(events)
-            old_new = compare_persons(
-                scraped_persons=persons,
-                known_persons=self.static_data.persons.values(),
-                primary_bodies=self.static_data.primary_bodies.values(),
-            )
-            self.handle_old_new_council(
-                old_names=old_new.old_names, new_names=old_new.new_names
-            )
+            have_primary_events = any(filter(lambda e: e.body.name in self.static_data.primary_bodies, events))
+            if have_primary_events:
+                persons = extract_persons(events)
+                old_new = compare_persons(
+                    scraped_persons=persons,
+                    known_persons=self.static_data.persons.values(),
+                    primary_bodies=self.static_data.primary_bodies.values(),
+                )
+                self.handle_old_new_council(
+                    old_names=old_new.old_names, new_names=old_new.new_names
+                )
 
         events = self.inject_known_data(events)
         events = self.post_process_ingestion_models(events)

--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -36,8 +36,6 @@ from cdp_backend.pipeline.ingestion_models import (
 from .legistar_content_parsers import all_parsers
 from .scraper_utils import (
     IngestionModelScraper,
-    compare_persons,
-    extract_persons,
     reduced_list,
     sanitize_roles,
     str_simplified,
@@ -1598,26 +1596,6 @@ class LegistarScraper(IngestionModelScraper):
         # easier for calling pipeline to handle an empty list rather than None
         # so request reduced_list() to give me [], not None
         events = reduced_list(ingestion_models, collapse=False)
-
-        if (
-            self.static_data
-            and any(self.static_data.persons)
-            and any(self.static_data.primary_bodies)
-        ):
-            have_primary_events = any(
-                filter(lambda e: e.body.name in self.static_data.primary_bodies, events)
-            )
-            if have_primary_events:
-                persons = extract_persons(events)
-                old_new = compare_persons(
-                    scraped_persons=persons,
-                    known_persons=self.static_data.persons.values(),
-                    primary_bodies=self.static_data.primary_bodies.values(),
-                )
-                self.handle_old_new_council(
-                    old_names=old_new.old_names, new_names=old_new.new_names
-                )
-
         events = self.inject_known_data(events)
         events = self.post_process_ingestion_models(events)
 

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -499,8 +499,8 @@ def compare_persons(scraped_persons, known_persons, primary_bodies) -> PersonsCo
         primary_body_names = filter(lambda b: b.name in body_names, primary_bodies)
         return any(primary_body_names)
 
-    active_persons = filter(lambda p: p and p.is_active, scraped_persons)
-    primary_persons = filter(holds_primary_role, active_persons)
+    active_persons = list(filter(lambda p: p and p.is_active, scraped_persons))
+    primary_persons = list(filter(holds_primary_role, active_persons))
     names = set([p.name for p in primary_persons])
 
     known_names = set([p.name for p in known_persons])

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -675,7 +675,7 @@ def extract_persons(events):
 
     def extract_voters(event_item):
         votes = event_item.votes or []
-        voters = map(Vote.Person, votes)
+        voters = map(lambda v: v.person, votes)
         voters = reduced_list(voters, collapse=False)
         return voters
 
@@ -685,7 +685,11 @@ def extract_persons(events):
     items = reduced_list(items, collapse=False)
 
     sponsors = map(extract_sponsors, items)
+    sponsors = chain.from_iterable(sponsors)
     voters = map(extract_voters, items)
-    persons = set(sponsors) | set(voters)
+    voters = chain.from_iterable(voters)
 
+    persons = chain(sponsors, voters)
+    persons = {p.name: p for p in persons}
+    persons = list(persons.values())
     return persons

--- a/cdp_scrapers/scraper_utils.py
+++ b/cdp_scrapers/scraper_utils.py
@@ -492,14 +492,14 @@ def extract_persons(events):
 def compare_persons(scraped_persons, known_persons, primary_bodies) -> PersonsComparison:
     def holds_primary_role(person):
         roles = person.seat.roles if person.seat and person.seat.roles else []
-        active_roles = filter(lambda r: r.end_datetime is None or datetime.today() <= r.end_datetime.date(), roles)
+        active_roles = filter(lambda r: r.end_datetime is None or datetime.today().date() <= r.end_datetime.date(), roles)
 
         body_names = map(lambda r: r.body.name if r.body else None, active_roles)
         body_names = reduced_list(body_names, collapse=False)
         primary_body_names = filter(lambda b: b.name in body_names, primary_bodies)
         return any(primary_body_names)
 
-    active_persons = filter(lambda p: p.is_active, scraped_persons)
+    active_persons = filter(lambda p: p and p.is_active, scraped_persons)
     primary_persons = filter(holds_primary_role, active_persons)
     names = set([p.name for p in primary_persons])
 

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -1,7 +1,7 @@
 from itertools import chain
 import random
 
-from cdp_backend.pipeline.ingestion_models import Matter, Person, Vote, EventMinutesItem, MinutesItem
+from cdp_backend.pipeline.ingestion_models import Matter, Person, Vote, EventMinutesItem, EventIngestionModel, MinutesItem
 import pytest
 
 from cdp_scrapers.scraper_utils import str_simplified
@@ -31,44 +31,95 @@ class TestExtractPersons:
     def make_persons(self, num_persons):
         return [Person(name=f"person_{i}") for i in range(num_persons)]
 
-    def make_sponsored_matters(self, num_matters, sponsors):
-        num_sponsors = len(sponsors)
-        num_sponsors_list = [random.randrange(num_sponsors + 1) for _ in range(num_matters)]
-        matter_sponsors = [random.choices(sponsors, k=k) for k in num_sponsors_list]
-
-        # Making sure at least one matter with all sponsors
+    def make_matters(self, num_matters, sponsors):
         if num_matters:
-            matter_sponsors[random.randrange(num_matters)] = sponsors
+            num_sponsors = [random.randrange(len(sponsors) + 1) for _ in range(num_matters)]
+            # At least one matter has all sponsors
+            num_sponsors[random.randrange(num_matters)] = len(sponsors)
 
-        matters = [
-            Matter(
-                name=f"matter_{i}",
-                matter_type=f"type_{i}",
-                title=f"title_{i}",
-                sponsors=_sponsors,
+            for i, k in enumerate(num_sponsors):
+                matter = Matter(
+                        name=f"matter_{i}",
+                        matter_type=f"type_{i}",
+                        title=f"title_{i}",
+                        sponsors=random.sample(sponsors, k),
+                    )
+                yield matter
+
+    def make_votes(self, num_items, voters):
+        if num_items:
+            num_voters = [random.randrange(len(voters) + 1) for _ in range(num_items)]
+            # At least one minutes item has all voters
+            num_voters[random.randrange(num_items)] = len(voters)
+
+            for i, k in enumerate(num_voters):
+                item_voters = random.sample(voters, k)
+                votes = [Vote(person=p, decision="Approve") for p in item_voters]
+                yield votes
+
+    def make_events(self, matters, votes):
+        matters_votes = zip(matters, votes)
+        items = [
+            EventMinutesItem(
+                minutes_item=None,
+                matter=matter,
+                votes=_votes,
             )
-            for i, _sponsors in enumerate(matter_sponsors)
+            for matter, _votes in matters_votes
         ]
-        return matters
+
+        while len(items):
+            num_items = random.randrange(len(items) + 1)
+            event_items = random.sample(items, num_items)
+            event = EventIngestionModel(
+                body=None,
+                sessions=[],
+                event_minutes_items=event_items
+            )
+            yield event
+
+            for item in event_items:
+                items.remove(item)
 
     @pytest.mark.parametrize("num_persons", [0, 1, 3])
     @pytest.mark.parametrize("num_matters", [0, 1, 3])
-    def test_helpers(self, num_persons, num_matters):
+    @pytest.mark.parametrize("num_sponsors", [0, 1, 3])
+    @pytest.mark.parametrize("num_voters", [0, 1, 3])
+    def test_helpers(self, num_persons, num_matters, num_sponsors, num_voters):
         persons = self.make_persons(num_persons)
         assert len(persons) == num_persons
 
-        matters = self.make_sponsored_matters(num_matters, persons)
-        matter_sponsors = [matter.sponsors or [] for matter in matters]
-        for sponsors in matter_sponsors:
-            assert len(sponsors) <= num_persons
-            for sponsor in sponsors:
-                assert sponsor in persons
+        num_sponsors = min(num_sponsors, num_persons)
+        num_voters = min(num_voters, num_persons)
+        _matters = [] if num_persons == 0 else self.make_matters(num_matters, random.sample(persons, num_sponsors))
+        _votes = [] if num_persons == 0 else self.make_votes(num_matters, random.sample(persons, num_voters))
+        events = self.make_events(_matters, _votes)
 
-        matter_sponsors = chain.from_iterable(matter_sponsors)
-        sponsor_names = set([p.name for p in matter_sponsors])
-        person_names = set([p.name for p in persons])
+        items = [e.event_minutes_items for e in events]
+        items = list(chain.from_iterable(items))
+        matters = [i.matter for i in items]
+
+        sponsors = [m.sponsors for m in matters]
+        sponsors = chain.from_iterable(sponsors)
+        names = set([p.name for p in sponsors])
 
         try:
-            assert sponsor_names == person_names
+            assert len(names) == num_sponsors
         except AssertionError:
-            assert len(sponsor_names) == 0 and num_matters == 0
+            assert len(names) == 0 and num_matters == 0
+
+        for sponsor in sponsors:
+            assert sponsor in persons
+
+        votes = [i.votes for i in items]
+        votes = chain.from_iterable(votes)
+        voters = [v.person for v in votes]
+        names = set([p.name for p in voters])
+
+        try:
+            assert len(names) == num_voters
+        except AssertionError:
+            assert len(names) == 0 and num_matters == 0
+
+        for voter in voters:
+            assert voter in persons

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -109,7 +109,7 @@ class TestExtractPersons:
         items = [e.event_minutes_items for e in events]
         items = list(chain.from_iterable(items))
 
-        # Compare input and output sponsors
+        # Test that the fake events contain input sponsors
         matters = [i.matter for i in items]
         sponsors = [m.sponsors for m in matters]
         sponsors = chain.from_iterable(sponsors)
@@ -123,7 +123,7 @@ class TestExtractPersons:
         for sponsor in sponsors:
             assert sponsor in persons
 
-        # Compare input and output voters
+        # Test that the fake events contain input voters
         votes = [i.votes for i in items]
         votes = chain.from_iterable(votes)
         voters = [v.person for v in votes]
@@ -149,3 +149,16 @@ class TestExtractPersons:
 
         extracted_persons = extract_persons(events)
         assert len(extracted_persons) == num_sponsors
+
+    @pytest.mark.parametrize("num_persons", [1, 3])
+    @pytest.mark.parametrize("num_matters", [1, 3])
+    @pytest.mark.parametrize("num_voters", [1, 3])
+    def test_extract_voters(self, num_persons, num_matters, num_voters):
+        persons = self.make_persons(num_persons)
+        assert len(persons) == num_persons
+
+        num_voters = min(num_voters, num_persons)
+        events = self.make_events(persons, num_matters, num_sponsors=0, num_voters=num_voters)
+
+        extracted_persons = extract_persons(events)
+        assert len(extracted_persons) == num_voters

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from itertools import chain
 import random
 
@@ -32,6 +33,7 @@ class TestExtractPersons:
         return [Person(name=f"person_{i}") for i in range(num_persons)]
 
     def make_matters(self, num_matters, sponsors):
+        """Make N Matters. Sponsors are randomly distributed"""
         if num_matters:
             num_sponsors = [random.randrange(len(sponsors) + 1) for _ in range(num_matters)]
             # At least one matter has all sponsors
@@ -47,6 +49,7 @@ class TestExtractPersons:
                 yield matter
 
     def make_votes(self, num_items, voters):
+        """Make N Votes. Voters are randomly distributed"""
         if num_items:
             num_voters = [random.randrange(len(voters) + 1) for _ in range(num_items)]
             # At least one minutes item has all voters
@@ -58,6 +61,7 @@ class TestExtractPersons:
                 yield votes
 
     def make_events_from_items(self, matters, votes):
+        """Combine Matters and Votes into EventIngestionModels. EventMinutesItems are randomly distributed"""
         matters_votes = zip(matters, votes)
         items = [
             EventMinutesItem(
@@ -82,6 +86,7 @@ class TestExtractPersons:
                 items.remove(item)
 
     def make_events(self, persons, num_matters, num_sponsors, num_voters):
+        """Make EventIngestionModels. Sponsors and voters are randomly distributed."""
         num_persons = len(persons)
 
         sponsors = [] if num_persons == 0 else random.sample(persons, num_sponsors)
@@ -98,6 +103,7 @@ class TestExtractPersons:
     @pytest.mark.parametrize("num_sponsors", [0, 1, 3])
     @pytest.mark.parametrize("num_voters", [0, 1, 3])
     def test_helpers(self, num_persons, num_matters, num_sponsors, num_voters):
+        """Sanity tests for the above helper methods"""
         persons = self.make_persons(num_persons)
         assert len(persons) == num_persons
 
@@ -141,6 +147,7 @@ class TestExtractPersons:
     @pytest.mark.parametrize("num_matters", [1, 3])
     @pytest.mark.parametrize("num_sponsors", [1, 3])
     def test_extract_sponsors(self, num_persons, num_matters, num_sponsors):
+        """Test that matter sponsors are extracted from events"""
         persons = self.make_persons(num_persons)
         assert len(persons) == num_persons
 
@@ -154,6 +161,7 @@ class TestExtractPersons:
     @pytest.mark.parametrize("num_matters", [1, 3])
     @pytest.mark.parametrize("num_voters", [1, 3])
     def test_extract_voters(self, num_persons, num_matters, num_voters):
+        """Test that voters are extractd from events"""
         persons = self.make_persons(num_persons)
         assert len(persons) == num_persons
 
@@ -167,6 +175,7 @@ class TestExtractPersons:
     @pytest.mark.parametrize("num_sponsors", [0, 1, 3])
     @pytest.mark.parametrize("num_voters", [0, 1, 3])
     def test_extract_persons(self, num_matters, num_sponsors, num_voters):
+        """Test that sponsors and voters are extracted from events"""
         num_persons = max(num_sponsors, num_voters)
         persons = self.make_persons(num_persons)
         assert len(persons) == num_persons

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -15,7 +15,8 @@ from cdp_backend.pipeline.ingestion_models import (
     Vote,
 )
 
-from cdp_scrapers.instances.portland import PortlandScraper, SCRAPER_STATIC_DATA as portland_static_data
+from cdp_scrapers.instances.portland import SCRAPER_STATIC_DATA as PORTLAND_STATIC_DATA
+from cdp_scrapers.instances.portland import PortlandScraper
 from cdp_scrapers.instances.seattle import SeattleScraper
 from cdp_scrapers.scraper_utils import compare_persons, extract_persons, str_simplified
 
@@ -353,14 +354,17 @@ class TestCompareExtractPersons:
     )
     @pytest.mark.parametrize("person", ["Jo Ann Hardesty", "Mary Hull Caballero"])
     def test_old_portland_member(self, begin, end, person):
-        """Test that we detect from real events those that are no longer in the council"""
+        """
+        Test that we detect from real events
+        those that are no longer in the council.
+        """
         s = PortlandScraper()
         events = s.get_events(begin=begin, end=end)
         scraped_persons = extract_persons(events)
         old_new = compare_persons(
             scraped_persons,
-            portland_static_data.persons.values(),
-            portland_static_data.primary_bodies.values(),
+            PORTLAND_STATIC_DATA.persons.values(),
+            PORTLAND_STATIC_DATA.primary_bodies.values(),
         )
 
         assert person in old_new.old_names

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -1,3 +1,6 @@
+import random
+
+from cdp_backend.pipeline.ingestion_models import Matter, Person, Vote
 import pytest
 
 from cdp_scrapers.scraper_utils import str_simplified
@@ -21,3 +24,46 @@ from cdp_scrapers.scraper_utils import str_simplified
 def test_str_simplifed(input_string: str, expected_output: str):
     # Validate that both methods work the same
     assert str_simplified(input_string) == expected_output
+
+
+class TestExtractPersons:
+    @pytest.fixture
+    def make_persons(self):
+        def _make(num_persons):
+            return [Person(name=f"person_{i}") for i in range(num_persons)]
+        return _make
+
+    @pytest.fixture
+    def make_sponsored_matters(self):
+        def _make(num_matters, sponsors):
+            num_sponsors = len(sponsors)
+            num_sponsors_list = [random.randrange(num_sponsors + 1) for _ in range(num_matters)]
+            # Making sure at least one matter with all sponsors
+            if num_matters:
+                num_sponsors_list[random.randrange(num_matters)] = num_sponsors
+            matter_sponsors = [random.choices(sponsors, k=k) for k in num_sponsors_list]
+
+            matters = [
+                Matter(
+                    name=f"matter_{i}",
+                    matter_type=f"type_{i}",
+                    title=f"title_{i}",
+                    sponsors=_sponsors,
+                )
+                for i, _sponsors in enumerate(matter_sponsors)
+            ]
+            return matters
+        return _make
+
+    @pytest.mark.parametrize("num_persons", [0, 1, 3])
+    @pytest.mark.parametrize("num_matters", [0, 1, 3])
+    def test_fixtures(self, num_persons, num_matters, make_persons, make_sponsored_matters):
+        persons = make_persons(num_persons)
+        assert len(persons) == num_persons
+
+        matters = make_sponsored_matters(num_matters, persons)
+        matter_sponsors = [matter.sponsors or [] for matter in matters]
+        for sponsors in matter_sponsors:
+            assert len(sponsors) <= num_persons
+            for sponsor in sponsors:
+                assert sponsor in persons

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -1,6 +1,7 @@
+from itertools import chain
 import random
 
-from cdp_backend.pipeline.ingestion_models import Matter, Person, Vote
+from cdp_backend.pipeline.ingestion_models import Matter, Person, Vote, EventMinutesItem, MinutesItem
 import pytest
 
 from cdp_scrapers.scraper_utils import str_simplified
@@ -27,43 +28,47 @@ def test_str_simplifed(input_string: str, expected_output: str):
 
 
 class TestExtractPersons:
-    @pytest.fixture
-    def make_persons(self):
-        def _make(num_persons):
-            return [Person(name=f"person_{i}") for i in range(num_persons)]
-        return _make
+    def make_persons(self, num_persons):
+        return [Person(name=f"person_{i}") for i in range(num_persons)]
 
-    @pytest.fixture
-    def make_sponsored_matters(self):
-        def _make(num_matters, sponsors):
-            num_sponsors = len(sponsors)
-            num_sponsors_list = [random.randrange(num_sponsors + 1) for _ in range(num_matters)]
-            # Making sure at least one matter with all sponsors
-            if num_matters:
-                num_sponsors_list[random.randrange(num_matters)] = num_sponsors
-            matter_sponsors = [random.choices(sponsors, k=k) for k in num_sponsors_list]
+    def make_sponsored_matters(self, num_matters, sponsors):
+        num_sponsors = len(sponsors)
+        num_sponsors_list = [random.randrange(num_sponsors + 1) for _ in range(num_matters)]
+        matter_sponsors = [random.choices(sponsors, k=k) for k in num_sponsors_list]
 
-            matters = [
-                Matter(
-                    name=f"matter_{i}",
-                    matter_type=f"type_{i}",
-                    title=f"title_{i}",
-                    sponsors=_sponsors,
-                )
-                for i, _sponsors in enumerate(matter_sponsors)
-            ]
-            return matters
-        return _make
+        # Making sure at least one matter with all sponsors
+        if num_matters:
+            matter_sponsors[random.randrange(num_matters)] = sponsors
+
+        matters = [
+            Matter(
+                name=f"matter_{i}",
+                matter_type=f"type_{i}",
+                title=f"title_{i}",
+                sponsors=_sponsors,
+            )
+            for i, _sponsors in enumerate(matter_sponsors)
+        ]
+        return matters
 
     @pytest.mark.parametrize("num_persons", [0, 1, 3])
     @pytest.mark.parametrize("num_matters", [0, 1, 3])
-    def test_fixtures(self, num_persons, num_matters, make_persons, make_sponsored_matters):
-        persons = make_persons(num_persons)
+    def test_helpers(self, num_persons, num_matters):
+        persons = self.make_persons(num_persons)
         assert len(persons) == num_persons
 
-        matters = make_sponsored_matters(num_matters, persons)
+        matters = self.make_sponsored_matters(num_matters, persons)
         matter_sponsors = [matter.sponsors or [] for matter in matters]
         for sponsors in matter_sponsors:
             assert len(sponsors) <= num_persons
             for sponsor in sponsors:
                 assert sponsor in persons
+
+        matter_sponsors = chain.from_iterable(matter_sponsors)
+        sponsor_names = set([p.name for p in matter_sponsors])
+        person_names = set([p.name for p in persons])
+
+        try:
+            assert sponsor_names == person_names
+        except AssertionError:
+            assert len(sponsor_names) == 0 and num_matters == 0

--- a/cdp_scrapers/tests/test_scraper_utils.py
+++ b/cdp_scrapers/tests/test_scraper_utils.py
@@ -162,3 +162,18 @@ class TestExtractPersons:
 
         extracted_persons = extract_persons(events)
         assert len(extracted_persons) == num_voters
+
+    @pytest.mark.parametrize("num_matters", [1, 3])
+    @pytest.mark.parametrize("num_sponsors", [0, 1, 3])
+    @pytest.mark.parametrize("num_voters", [0, 1, 3])
+    def test_extract_persons(self, num_matters, num_sponsors, num_voters):
+        num_persons = max(num_sponsors, num_voters)
+        persons = self.make_persons(num_persons)
+        assert len(persons) == num_persons
+
+        num_sponsors = min(num_sponsors, num_persons)
+        num_voters = min(num_voters, num_persons)
+        events = self.make_events(persons, num_matters, num_sponsors, num_voters)
+
+        extracted_persons = extract_persons(events)
+        assert len(extracted_persons) == num_persons

--- a/cdp_scrapers/types.py
+++ b/cdp_scrapers/types.py
@@ -19,6 +19,11 @@ class ScraperStaticData(NamedTuple):
     persons: Dict[str, Person] = None
 
 
+class PersonsComparison(NamedTuple):
+    old_names: List[str] = []
+    new_names: List[str] = []
+
+
 LegistarContentParser = Callable[[str, BeautifulSoup], Optional[List[ContentURIs]]]
 """
 Function that returns URLs for videos and captions


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is part of #135 

### Description of Changes

#### `extract_persons`, `compare_persons`

Helpers to find out when `ScraperStaticData` potentially needs updating. No scraper is using these helper methods for the time being.

Not a complete solution by any means, but should be helpful in detecting obvious council changes.

#### Portland, OR

Added [basic info for] Rene Gonzalez and updated Dan Ryan.