### PR TITLE
bugfix/fix-houston-scraper

### DIFF
--- a/cdp_scrapers/instances/houston.py
+++ b/cdp_scrapers/instances/houston.py
@@ -1,5 +1,5 @@
-import logging
 import enum
+import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class AgendaType(enum.IntEnum):
     WebPage = enum.auto()
     Pdf = enum.auto()
+
 
 class HoustonScraper(IngestionModelScraper):
     def __init__(self):
@@ -62,7 +63,7 @@ class HoustonScraper(IngestionModelScraper):
             # Assuming event is a tr from search results
             # and that the first td contains the committee name
             cell_text = event.find("td").text.strip()
-            return cell_text[:cell_text.find("(")].strip()
+            return cell_text[: cell_text.find("(")].strip()
 
         if "CITY COUNCIL" in body_table.text:
             return "City Council"
@@ -170,7 +171,9 @@ class HoustonScraper(IngestionModelScraper):
             return AgendaType.WebPage, form1
         elif page.content.startswith(b"%PDF"):
             return AgendaType.Pdf, agenda_link
-        raise NotImplementedError(f"{agenda_link} points to unrecognized agenda resource")
+        raise NotImplementedError(
+            f"{agenda_link} points to unrecognized agenda resource"
+        )
 
     def get_event(
         self, date: str, element: Tag
@@ -209,7 +212,9 @@ class HoustonScraper(IngestionModelScraper):
                     session_index=0,
                 )
             ],
-            event_minutes_items=self.get_event_minutes_item(agenda) if agenda_type == AgendaType.WebPage else None,
+            event_minutes_items=self.get_event_minutes_item(agenda)
+            if agenda_type == AgendaType.WebPage
+            else None,
             agenda_uri=main_uri + "/agenda",
         )
         return event
@@ -243,7 +248,10 @@ class HoustonScraper(IngestionModelScraper):
         def query_for_date(event_date):
             # https://houstontx.new.swagit.com/videos/search?q=january+11+2022
             # NOTE: do not use %d for day; the search will not work with zero-padded day
-            main_url = f"https://houstontx.new.swagit.com/videos/search?q={event_date.strftime('%B')}+{event_date.day}+{event_date.year}"
+            main_url = (
+                "https://houstontx.new.swagit.com/videos/search"
+                f"?q={event_date.strftime('%B')}+{event_date.day}+{event_date.year}"
+            )
             main_page = requests.get(main_url)
             main = BeautifulSoup(main_page.content, "html.parser")
             main_table = main.find("table")

--- a/cdp_scrapers/instances/houston.py
+++ b/cdp_scrapers/instances/houston.py
@@ -158,8 +158,8 @@ class HoustonScraper(IngestionModelScraper):
 
         Returns
         -------
-        Tag
-            The agenda web page we want parse
+        AgendaType, Tag
+            Resource type for the agenda and the agenda resource itself
         """
         link = self.get_date_mainlink(element)
         agenda_link = link + "/agenda"
@@ -240,12 +240,14 @@ class HoustonScraper(IngestionModelScraper):
         """
 
         def get_search_dates():
+            """Return iterator over dates to search."""
             event_date = time_from.date()
             while event_date <= time_to.date():
                 yield event_date
                 event_date += timedelta(days=1)
 
         def query_for_date(event_date):
+            """Return event date and <table> element in search result HTML."""
             # https://houstontx.new.swagit.com/videos/search?q=january+11+2022
             # NOTE: do not use %d for day; the search will not work with zero-padded day
             main_url = (

--- a/cdp_scrapers/tests/test_scrapers.py
+++ b/cdp_scrapers/tests/test_scrapers.py
@@ -24,10 +24,10 @@ from cdp_scrapers.instances.seattle import SeattleScraper
         (
             datetime(2022, 11, 7),
             datetime(2022, 11, 16),
-            2,
-            33,
+            3,
+            31,
             "https://houston.novusagenda.com/agendapublic/"
-            "CoverSheet.aspx?ItemID=27102&MeetingID=566",
+            "CoverSheet.aspx?ItemID=26951&MeetingID=565",
         ),
     ],
 )

--- a/cdp_scrapers/tests/test_scrapers.py
+++ b/cdp_scrapers/tests/test_scrapers.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-# from cdp_scrapers.instances.houston import HoustonScraper
+from cdp_scrapers.instances.houston import HoustonScraper
 from cdp_scrapers.instances.kingcounty import KingCountyScraper
 from cdp_scrapers.instances.portland import PortlandScraper
 from cdp_scrapers.instances.seattle import SeattleScraper


### PR DESCRIPTION
### Link to Relevant Issue

https://github.com/CouncilDataProject/cdp-scrapers/actions/runs/6150355264/job/16688128572#step:6:223

### Description of Changes

[Main web page for Houston](https://houstontx.new.swagit.com/views/408/) has changed enough since we last worked on it to break the scraper.

- Instead of parsing for elements for some date/year on that web page, we are now requesting a search query for each date in the date range passed to `get_events`. The search results web page is similar enough that existing code can be used without significant changes.

- Be able to handle events with agendas attached as PDF not as web page HTML.