### PR TITLE
#145: bug/get_legistar_content_uris - adjusting inital media URL extraction

### DIFF
--- a/cdp_scrapers/legistar_utils.py
+++ b/cdp_scrapers/legistar_utils.py
@@ -515,15 +515,10 @@ def get_legistar_content_uris(client: str, legistar_ev: dict) -> ContentUriScrap
     # return false;"
     # href="#" style="color:Blue;font-family:Tahoma;font-size:10pt;">Video</a>
     extract_url = soup.find(
-        "a",
-        id=re.compile(r"ct\S*_ContentPlaceHolder\S*_hypVideo"),
-        class_="videolink",
+        "a", id=re.compile(r"ct\S*_ContentPlaceHolder\S*_hypVideo"), onclick=True
     )
     if extract_url is None:
         return (ContentUriScrapeResult.Status.UnrecognizedPatternError, None)
-    # the <a> tag will not have this attribute if there is no video
-    if "onclick" not in extract_url.attrs:
-        return (ContentUriScrapeResult.Status.ContentNotProvidedError, None)
 
     # NOTE: after this point, failing to scrape video url should raise an exception.
     # we need to be alerted that we probabaly have a new web page structure.


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #145.

### Description of Changes

1. Removes `videolink` class criteria - some media links do not have a `videolink` class assigned. The highly specific ID should be enough to distinguish potentially relevant links.
1. The `BeautifulSoup` `find` call only identifies the first media link instance - an example provided in the issue shows the first media link is not always associated with a video, resulting in a failure to identify video for the entire event.
1. `onclick` is a distinguishing attribute for links with video content - while checked subsequently to provide a unique error, this code tests for the presence of the `onclick` attribute to more quickly identify the first valid media link.
